### PR TITLE
CI: cache ~/.m2 correctly

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,24 +13,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-m2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Set up JDK 8
+      - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
-          java-package: jdk+fx
+          java-version: '8'
+          java-package: 'jdk+fx'
+      - name: Cache Maven artifacts
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Set up CI environment
         run: .github/setup.sh
       - name: Execute the build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,24 +11,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-m2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Set up JDK 8
+      - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
-          java-package: jdk+fx
+          java-version: '8'
+          java-package: 'jdk+fx'
+      - name: Cache Maven artifacts
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Set up CI environment
         run: .github/setup.sh
       - name: Execute the build


### PR DESCRIPTION
For the cache to work, we need to use hashFiles on the pom.xml contents.

Unfortunately, we have to use actions/cache rather than the `cache: maven` option of setup-java v2+, because we are stuck on setup-java v1 in order to install Zulu JDK+FX 8.

In my tests, this change halved the build time ([2 min 3 sec before](https://github.com/scijava/scijava-repl-fx/actions/runs/2504496499/attempts/1) versus [48 sec after](https://github.com/scijava/scijava-repl-fx/actions/runs/2504496499/attempts/2)).
