### PR TITLE
Migrate from FontAwesomeFX to Ikonli for icon rendering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,11 +131,7 @@
 		<flexmark-util-misc.version>${flexmark.version}</flexmark-util-misc.version>
 		<flexmark-util-sequence.version>${flexmark.version}</flexmark-util-sequence.version>
 
-		<fontawesomefx-commons.version>11.0</fontawesomefx-commons.version>
-		<fontawesomefx-controls.version>11.0</fontawesomefx-controls.version>
-		<fontawesomefx-fontawesome.version>4.7.0-11</fontawesomefx-fontawesome.version>
-		<fontawesomefx-materialicons.version>2.2.0-11</fontawesomefx-materialicons.version>
-		<fontawesomefx-octicons.version>4.3.0-11</fontawesomefx-octicons.version>
+		<ikonli.version>12.4.0</ikonli.version>
 
 		<annotations.version>26.0.2</annotations.version>
 		<controlsfx.version>11.2.2</controlsfx.version>
@@ -453,124 +449,24 @@
 			<version>${chartfx-math.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>de.jensd</groupId>
-			<artifactId>fontawesomefx-commons</artifactId>
-			<version>${fontawesomefx-commons.version}</version>
-			<exclusions>
-				<!-- Exclude all older JavaFX versions -->
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.kordamp.ikonli</groupId>
+			<artifactId>ikonli-javafx</artifactId>
+			<version>${ikonli.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>de.jensd</groupId>
-			<artifactId>fontawesomefx-controls</artifactId>
-			<version>${fontawesomefx-controls.version}</version>
-			<exclusions>
-				<!-- Exclude all older JavaFX versions -->
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.kordamp.ikonli</groupId>
+			<artifactId>ikonli-fontawesome-pack</artifactId>
+			<version>${ikonli.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>de.jensd</groupId>
-			<artifactId>fontawesomefx-fontawesome</artifactId>
-			<version>${fontawesomefx-fontawesome.version}</version>
-			<exclusions>
-				<!-- Exclude all older JavaFX versions -->
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.kordamp.ikonli</groupId>
+			<artifactId>ikonli-material-pack</artifactId>
+			<version>${ikonli.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>de.jensd</groupId>
-			<artifactId>fontawesomefx-materialicons</artifactId>
-			<version>${fontawesomefx-materialicons.version}</version>
-			<exclusions>
-				<!-- Exclude all older JavaFX versions -->
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>de.jensd</groupId>
-			<artifactId>fontawesomefx-octicons</artifactId>
-			<version>${fontawesomefx-octicons.version}</version>
-			<exclusions>
-				<!-- Exclude all older JavaFX versions -->
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.kordamp.ikonli</groupId>
+			<artifactId>ikonli-octicons-pack</artifactId>
+			<version>${ikonli.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/de/mpg/biochem/mars/fx/controls/BrowseDirectoryButton.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/controls/BrowseDirectoryButton.java
@@ -57,9 +57,10 @@ package de.mpg.biochem.mars.fx.controls;
 
 import java.io.File;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.Messages;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Tooltip;
 import javafx.stage.DirectoryChooser;
@@ -73,8 +74,7 @@ import javafx.stage.DirectoryChooser;
 public class BrowseDirectoryButton extends BrowseFileButton {
 
 	public BrowseDirectoryButton() {
-		setGraphic(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.FOLDER_ALT, "1.2em"));
+		setGraphic(ActionUtils.icon(FontAwesome.FOLDER_OPEN_O, "1.2em"));
 		setTooltip(new Tooltip(Messages.get("BrowseDirectoryButton.tooltip")));
 	}
 

--- a/src/main/java/de/mpg/biochem/mars/fx/controls/BrowseFileButton.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/controls/BrowseFileButton.java
@@ -60,9 +60,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.Messages;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.event.ActionEvent;
@@ -84,8 +85,7 @@ public class BrowseFileButton extends Button {
 	private final List<ExtensionFilter> extensionFilters = new ArrayList<>();
 
 	public BrowseFileButton() {
-		setGraphic(FontAwesomeIconFactory.get().createIcon(FontAwesomeIcon.FILE_ALT,
-			"1.2em"));
+		setGraphic(ActionUtils.icon(FontAwesome.FILE_O, "1.2em"));
 		setTooltip(new Tooltip(Messages.get("BrowseFileButton.tooltip")));
 		setOnAction(this::browse);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/controls/FileTreeCell.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/controls/FileTreeCell.java
@@ -57,8 +57,9 @@ package de.mpg.biochem.mars.fx.controls;
 
 import java.io.File;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.Utils;
 import javafx.scene.Node;
 import javafx.scene.control.TreeCell;
@@ -95,15 +96,15 @@ public class FileTreeCell extends TreeCell<File> {
 		Node graphic = null;
 		if (!empty && file != null) {
 			text = file.getName();
-			graphic = FontAwesomeIconFactory.get().createIcon(getTreeItem().isLeaf()
-				? fileIcon(text) : FontAwesomeIcon.FOLDER_ALT);
+			graphic = ActionUtils.icon(getTreeItem().isLeaf()
+				? fileIcon(text) : FontAwesome.FOLDER_OPEN_O);
 		}
 		setText(text);
 		setGraphic(graphic);
 	}
 
-	private FontAwesomeIcon fileIcon(String name) {
-		return Utils.isImage(name) ? FontAwesomeIcon.FILE_IMAGE_ALT
-			: FontAwesomeIcon.FILE_TEXT_ALT;
+	private FontAwesome fileIcon(String name) {
+		return Utils.isImage(name) ? FontAwesome.FILE_IMAGE_O
+			: FontAwesome.FILE_TEXT_O;
 	}
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractBeakerWidget.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractBeakerWidget.java
@@ -29,7 +29,7 @@
 
 package de.mpg.biochem.mars.fx.dashboard;
 
-import static de.jensd.fx.glyphs.octicons.OctIcon.BEAKER;
+import static org.kordamp.ikonli.octicons.Octicons.BEAKER_24;
 
 import java.util.Map;
 
@@ -37,7 +37,7 @@ import net.imagej.ops.Initializable;
 
 import org.scijava.plugin.SciJavaPlugin;
 
-import de.jensd.fx.glyphs.octicons.utils.OctIconFactory;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.layout.BorderPane;
@@ -62,7 +62,7 @@ public abstract class AbstractBeakerWidget extends AbstractScriptableWidget
 
 	@Override
 	public Node getIcon() {
-		return (Node) OctIconFactory.get().createIcon(BEAKER, "1.2em");
+		return (Node) ActionUtils.icon(BEAKER_24, "1.2em");
 	}
 
 	@Override

--- a/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboard.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboard.java
@@ -29,9 +29,9 @@
 
 package de.mpg.biochem.mars.fx.dashboard;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.BOMB;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.STOP;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.BOMB;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.REFRESH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.STOP;
 
 import com.fasterxml.jackson.core.JsonToken;
 

--- a/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboardWidget.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboardWidget.java
@@ -29,18 +29,17 @@
 
 package de.mpg.biochem.mars.fx.dashboard;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CLOSE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.QUESTION_CIRCLE_ALT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.TIMES;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.QUESTION_CIRCLE_O;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.REFRESH;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.scijava.plugin.Parameter;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
-import de.jensd.fx.glyphs.octicons.utils.OctIconFactory;
 import de.mpg.biochem.mars.fx.dialogs.RoverConfirmationDialog;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.molecule.AbstractJsonConvertibleRecord;
 import javafx.animation.Animation;
 import javafx.animation.Interpolator;
@@ -118,7 +117,7 @@ public abstract class AbstractDashboardWidget extends
 		// the
 		// widget...
 
-		Text closeIcon = OctIconFactory.get().createIcon(CLOSE, "1.0em");
+		Text closeIcon = ActionUtils.icon(TIMES, "1.0em");
 		closeButton = new Button();
 		closeButton.setPickOnBounds(true);
 		closeButton.setCenterShape(true);
@@ -133,7 +132,7 @@ public abstract class AbstractDashboardWidget extends
 		closeButton.setPrefWidth(20);
 		closeButton.setPrefHeight(20);
 
-		syncIcon = OctIconFactory.get().createIcon(REFRESH, "1.0em");
+		syncIcon = ActionUtils.icon(REFRESH, "1.0em");
 		loadButton = new Button();
 		loadButton.setGraphic(syncIcon);
 		loadButton.setCenterShape(true);
@@ -315,8 +314,7 @@ public abstract class AbstractDashboardWidget extends
 
 	@Override
 	public Node getIcon() {
-		return (Node) FontAwesomeIconFactory.get().createIcon(QUESTION_CIRCLE_ALT,
-			"1.0em");
+		return (Node) ActionUtils.icon(QUESTION_CIRCLE_O, "1.0em");
 	}
 
 	@Override

--- a/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractScriptableWidget.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractScriptableWidget.java
@@ -29,8 +29,8 @@
 
 package de.mpg.biochem.mars.fx.dashboard;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.BOOK;
-import static de.jensd.fx.glyphs.octicons.OctIcon.CODE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.BOOK;
+import static org.kordamp.ikonli.octicons.Octicons.CODE_16;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -63,8 +63,8 @@ import org.scijava.script.ScriptLanguage;
 import org.scijava.script.ScriptModule;
 import org.scijava.script.ScriptService;
 
-import de.jensd.fx.glyphs.octicons.utils.OctIconFactory;
 import de.mpg.biochem.mars.fx.editor.MarsScriptEditor;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
@@ -132,7 +132,7 @@ public abstract class AbstractScriptableWidget extends AbstractDashboardWidget
 
 		// Script Pane
 		Tab scriptTab = new Tab();
-		scriptTab.setGraphic(OctIconFactory.get().createIcon(CODE, "1.0em"));
+		scriptTab.setGraphic(ActionUtils.icon(CODE_16, "1.0em"));
 
 		codeArea = new MarsScriptEditor();
 
@@ -172,7 +172,7 @@ public abstract class AbstractScriptableWidget extends AbstractDashboardWidget
 
 		Tab logTab = new Tab();
 		logTab.setContent(borderPane);
-		logTab.setGraphic(OctIconFactory.get().createIcon(BOOK, "1.0em"));
+		logTab.setGraphic(ActionUtils.icon(BOOK, "1.0em"));
 		getTabPane().getTabs().add(logTab);
 
 		if (lang.getLanguageName().equals("Python (scyjava)")) loadImage();

--- a/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/CloudArchiveOpenWindow.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/CloudArchiveOpenWindow.java
@@ -41,8 +41,9 @@ import javax.swing.SwingUtilities;
 
 import com.amazonaws.AmazonServiceException;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.IJStage;
 import de.mpg.biochem.mars.fx.util.MarsThemeManager;
 import de.mpg.biochem.mars.n5.MarsS3Browser;
@@ -224,8 +225,7 @@ public class CloudArchiveOpenWindow {
                 }
                 else {
                     setText(bucket);
-                    setGraphic(FontAwesomeIconFactory.get().createIcon(
-                            FontAwesomeIcon.ARCHIVE, "1.0em"));
+                    setGraphic(ActionUtils.icon(FontAwesome.ARCHIVE, "1.0em"));
                 }
             }
         });

--- a/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/CloudArchiveSaveDialog.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/CloudArchiveSaveDialog.java
@@ -37,8 +37,9 @@ import java.util.prefs.Preferences;
 
 import com.amazonaws.AmazonServiceException;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.MarsThemeManager;
 import de.mpg.biochem.mars.n5.MarsS3Browser;
 import javafx.application.Platform;
@@ -194,8 +195,7 @@ public class CloudArchiveSaveDialog extends Dialog<String> {
                 }
                 else {
                     setText(bucket);
-                    setGraphic(FontAwesomeIconFactory.get().createIcon(
-                            FontAwesomeIcon.ARCHIVE, "1.0em"));
+                    setGraphic(ActionUtils.icon(FontAwesome.ARCHIVE, "1.0em"));
                 }
             }
         });

--- a/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/explorer/DatasetExplorerWindow.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/explorer/DatasetExplorerWindow.java
@@ -60,8 +60,10 @@ import javafx.scene.control.TitledPane;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+import org.kordamp.ikonli.octicons.Octicons;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.scene.layout.*;
 import javafx.stage.Stage;
 
@@ -427,12 +429,12 @@ public class DatasetExplorerWindow {
 
         Tab cloudTab = new Tab();
         cloudTab.setClosable(false);
-        cloudTab.setGraphic(tabGraphic(FontAwesomeIcon.CLOUD, tabWidth));
+        cloudTab.setGraphic(tabGraphic(FontAwesome.CLOUD, tabWidth));
         cloudTab.setContent(cloudBox);
 
         Tab folderTab = new Tab();
         folderTab.setClosable(false);
-        folderTab.setGraphic(tabGraphic(FontAwesomeIcon.FOLDER, tabWidth));
+        folderTab.setGraphic(tabGraphic(FontAwesome.FOLDER, tabWidth));
         folderTab.setContent(folderBox);
 
         sourceTabs.getTabs().addAll(cloudTab, folderTab);
@@ -557,8 +559,7 @@ public class DatasetExplorerWindow {
                     setContextMenu(null);
                 } else {
                     setText(item);
-                    setGraphic(FontAwesomeIconFactory.get().createIcon(
-                            FontAwesomeIcon.FOLDER, "1.0em"));
+                    setGraphic(ActionUtils.icon(FontAwesome.FOLDER, "1.0em"));
                     javafx.scene.control.MenuItem remove =
                             new javafx.scene.control.MenuItem("Remove (and delete cache)");
                     remove.setOnAction(e -> removeProject(item));
@@ -605,8 +606,7 @@ public class DatasetExplorerWindow {
                 } else {
                     setText(item);
                     // Same icon factory the archive dialog uses, so it themes identically.
-                    setGraphic(FontAwesomeIconFactory.get().createIcon(
-                            FontAwesomeIcon.ARCHIVE, "1.0em"));
+                    setGraphic(ActionUtils.icon(FontAwesome.ARCHIVE, "1.0em"));
                 }
             }
         };
@@ -662,10 +662,10 @@ public class DatasetExplorerWindow {
 
     private Region buildDatasetsContent() {
         // --- Row 1: collapse buttons, search, type toggles, date-filter toggle ---
-        toggleLeftBtn = iconButton(FontAwesomeIcon.CHEVRON_LEFT, "Show/hide connection pane");
+        toggleLeftBtn = iconButton(FontAwesome.CHEVRON_LEFT, "Show/hide connection pane");
         toggleLeftBtn.setOnAction(e -> toggleLeftPane());
 
-        toggleRightBtn = iconButton(FontAwesomeIcon.CHEVRON_RIGHT, "Show/hide details pane");
+        toggleRightBtn = iconButton(FontAwesome.CHEVRON_RIGHT, "Show/hide details pane");
         toggleRightBtn.setOnAction(e -> toggleRightPane());
 
         searchField = new TextField();
@@ -718,8 +718,7 @@ public class DatasetExplorerWindow {
 
         // Sort toggle: reveals/hides the second row holding the sort dropdown.
         ToggleButton sortToggle = new ToggleButton();
-        sortToggle.setGraphic(FontAwesomeIconFactory.get().createIcon(
-                FontAwesomeIcon.SORT, "1.0em"));
+        sortToggle.setGraphic(ActionUtils.icon(FontAwesome.SORT, "1.0em"));
         sortToggle.setTooltip(new javafx.scene.control.Tooltip("Sort options"));
         styleFilterToggle(sortToggle);
         sortToggle.selectedProperty().addListener((o, a, b) -> styleFilterToggle(sortToggle));
@@ -766,9 +765,9 @@ public class DatasetExplorerWindow {
     }
 
     /** A small icon-only button using a FontAwesome glyph. */
-    private static Button iconButton(FontAwesomeIcon glyph, String tooltip) {
+    private static Button iconButton(FontAwesome glyph, String tooltip) {
         Button b = new Button();
-        b.setGraphic(FontAwesomeIconFactory.get().createIcon(glyph, "1.1em"));
+        b.setGraphic(ActionUtils.icon(glyph, "1.1em"));
         b.setTooltip(new javafx.scene.control.Tooltip(tooltip));
         return b;
     }
@@ -837,7 +836,7 @@ public class DatasetExplorerWindow {
 
         Tab infoTab = new Tab();
         infoTab.setClosable(false);
-        infoTab.setGraphic(tabGraphic(FontAwesomeIcon.INFO_CIRCLE, tabWidth));
+        infoTab.setGraphic(tabGraphic(FontAwesome.INFO_CIRCLE, tabWidth));
         infoTab.setContent(infoContent);
 
         Tab codeTab = new Tab();
@@ -845,8 +844,7 @@ public class DatasetExplorerWindow {
         // Code icon: octicon CODE, matching the scriptable-widget tab glyph.
         BorderPane codeGraphic = new BorderPane();
         codeGraphic.setMaxWidth(tabWidth);
-        codeGraphic.setCenter(de.jensd.fx.glyphs.octicons.utils.OctIconFactory.get()
-                .createIcon(de.jensd.fx.glyphs.octicons.OctIcon.CODE, "1.1em"));
+        codeGraphic.setCenter(ActionUtils.icon(Octicons.CODE_16, "1.1em"));
         codeTab.setGraphic(codeGraphic);
         if (context != null) {
             scriptPane = new DatasetScriptPane(context);
@@ -884,10 +882,10 @@ public class DatasetExplorerWindow {
     }
 
     /** A BorderPane-centered FontAwesome glyph for a fixed-width icon tab. */
-    private static BorderPane tabGraphic(FontAwesomeIcon glyph, double tabWidth) {
+    private static BorderPane tabGraphic(FontAwesome glyph, double tabWidth) {
         BorderPane p = new BorderPane();
         p.setMaxWidth(tabWidth);
-        p.setCenter(FontAwesomeIconFactory.get().createIcon(glyph, "1.1em"));
+        p.setCenter(ActionUtils.icon(glyph, "1.1em"));
         return p;
     }
 
@@ -1009,11 +1007,11 @@ public class DatasetExplorerWindow {
             // Remember the left divider position before collapsing.
             savedLeftDivider = split.getDividerPositions()[0];
             split.getItems().remove(leftPane);
-            setButtonIcon(toggleLeftBtn, FontAwesomeIcon.CHEVRON_RIGHT); // closed → point to content
+            setButtonIcon(toggleLeftBtn, FontAwesome.CHEVRON_RIGHT); // closed → point to content
         } else {
             split.getItems().add(0, leftPane);
             Platform.runLater(() -> restoreDividers());
-            setButtonIcon(toggleLeftBtn, FontAwesomeIcon.CHEVRON_LEFT); // open → point to pane
+            setButtonIcon(toggleLeftBtn, FontAwesome.CHEVRON_LEFT); // open → point to pane
         }
     }
 
@@ -1024,11 +1022,11 @@ public class DatasetExplorerWindow {
             double[] d = split.getDividerPositions();
             if (d.length > 0) savedRightDivider = d[d.length - 1];
             split.getItems().remove(rightPane);
-            setButtonIcon(toggleRightBtn, FontAwesomeIcon.CHEVRON_LEFT); // closed → point to content
+            setButtonIcon(toggleRightBtn, FontAwesome.CHEVRON_LEFT); // closed → point to content
         } else {
             split.getItems().add(rightPane);
             Platform.runLater(() -> restoreDividers());
-            setButtonIcon(toggleRightBtn, FontAwesomeIcon.CHEVRON_RIGHT); // open → point to pane
+            setButtonIcon(toggleRightBtn, FontAwesome.CHEVRON_RIGHT); // open → point to pane
         }
     }
 
@@ -1050,8 +1048,8 @@ public class DatasetExplorerWindow {
         }
     }
 
-    private static void setButtonIcon(Button b, FontAwesomeIcon glyph) {
-        b.setGraphic(FontAwesomeIconFactory.get().createIcon(glyph, "1.1em"));
+    private static void setButtonIcon(Button b, FontAwesome glyph) {
+        b.setGraphic(ActionUtils.icon(glyph, "1.1em"));
     }
 
     // -----------------------------------------------------------------

--- a/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/explorer/DatasetNotesPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/explorer/DatasetNotesPane.java
@@ -30,8 +30,9 @@ package de.mpg.biochem.mars.fx.dialogs.s3.explorer;
 
 import java.util.function.Consumer;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+import org.kordamp.ikonli.javafx.FontIcon;
+
 import de.mpg.biochem.mars.fx.editor.MarkdownEditorPane;
 import de.mpg.biochem.mars.fx.options.Options;
 import de.mpg.biochem.mars.fx.webview.MarkdownPreviewPane;
@@ -152,7 +153,7 @@ public class DatasetNotesPane extends BorderPane {
 
         // --- Toolbar ---
         editToggle = new ToggleButton();
-        editToggle.setGraphic(icon(FontAwesomeIcon.PENCIL));
+        editToggle.setGraphic(icon(FontAwesome.PENCIL));
         editToggle.setTooltip(new Tooltip("Edit notes"));
         editToggle.selectedProperty().addListener((o, was, on) -> setEditMode(on));
 
@@ -179,18 +180,18 @@ public class DatasetNotesPane extends BorderPane {
 
     private HBox buildFormatBar() {
         // Undo / redo (operate on the editor's undo manager).
-        Button undo = formatButton(FontAwesomeIcon.UNDO, "Undo",
+        Button undo = formatButton(FontAwesome.UNDO, "Undo",
                 () -> editorPane.undo());
-        Button redo = formatButton(FontAwesomeIcon.REPEAT, "Redo",
+        Button redo = formatButton(FontAwesome.REPEAT, "Redo",
                 () -> editorPane.redo());
 
-        Button bold = formatButton(FontAwesomeIcon.BOLD, "Bold",
+        Button bold = formatButton(FontAwesome.BOLD, "Bold",
                 () -> editorPane.getSmartEdit().insertBold("bold"));
-        Button italic = formatButton(FontAwesomeIcon.ITALIC, "Italic",
+        Button italic = formatButton(FontAwesome.ITALIC, "Italic",
                 () -> editorPane.getSmartEdit().insertItalic("italic"));
-        Button strike = formatButton(FontAwesomeIcon.STRIKETHROUGH, "Strikethrough",
+        Button strike = formatButton(FontAwesome.STRIKETHROUGH, "Strikethrough",
                 () -> editorPane.getSmartEdit().insertStrikethrough("strikethrough"));
-        Button code = formatButton(FontAwesomeIcon.CODE, "Inline code",
+        Button code = formatButton(FontAwesome.CODE, "Inline code",
                 () -> editorPane.getSmartEdit().insertInlineCode("code"));
 
         Button h1 = textButton("H1", "Heading 1",
@@ -204,11 +205,11 @@ public class DatasetNotesPane extends BorderPane {
         // SmartEdit.insertUnorderedList(), which reads Options.getBulletListMarker()
         // — that returns null outside an archive/Options context and inserts the
         // literal text "null". Explicit markers avoid that entirely.
-        Button bullet = formatButton(FontAwesomeIcon.LIST_UL, "Bulleted list",
+        Button bullet = formatButton(FontAwesome.LIST_UL, "Bulleted list",
                 () -> editorPane.getSmartEdit().surroundSelection("\n\n- ", ""));
-        Button numbered = formatButton(FontAwesomeIcon.LIST_OL, "Numbered list",
+        Button numbered = formatButton(FontAwesome.LIST_OL, "Numbered list",
                 () -> editorPane.getSmartEdit().surroundSelection("\n\n1. ", ""));
-        Button quote = formatButton(FontAwesomeIcon.QUOTE_LEFT, "Block quote",
+        Button quote = formatButton(FontAwesome.QUOTE_LEFT, "Block quote",
                 () -> editorPane.getSmartEdit().surroundSelection("\n\n> ", ""));
 
         HBox bar = new HBox(2, undo, redo, sep(), bold, italic, strike, code,
@@ -386,7 +387,7 @@ public class DatasetNotesPane extends BorderPane {
 
     // ---- button helpers ------------------------------------------------
 
-    private Button formatButton(FontAwesomeIcon glyph, String tip, Runnable action) {
+    private Button formatButton(FontAwesome glyph, String tip, Runnable action) {
         Button b = new Button();
         b.setGraphic(icon(glyph));
         b.setTooltip(new Tooltip(tip));
@@ -416,11 +417,10 @@ public class DatasetNotesPane extends BorderPane {
         return r;
     }
 
-    // Single place that builds FontAwesome glyphs — change this one method when
-    // migrating to Ikonli.
-    private static FontAwesomeIconView icon(FontAwesomeIcon glyph) {
-        FontAwesomeIconView view = new FontAwesomeIconView(glyph);
-        view.setGlyphSize(14);
+    // Single place that builds FontAwesome glyphs.
+    private static FontIcon icon(FontAwesome glyph) {
+        FontIcon view = new FontIcon(glyph);
+        view.setIconSize(14);
         return view;
     }
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/editor/FindReplacePane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/editor/FindReplacePane.java
@@ -80,9 +80,10 @@ import org.fxmisc.richtext.MultiChangeBuilder;
 import org.fxmisc.richtext.model.TwoDimensional.Bias;
 import org.fxmisc.wellbehaved.event.Nodes;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.Messages;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.MarsFxGlobalPreferences;
 import de.mpg.biochem.mars.fx.util.PrefsBooleanProperty;
 import de.mpg.biochem.mars.fx.util.Range;
@@ -456,12 +457,9 @@ class FindReplacePane {
 		findInfoLabel.getStyleClass().add("info");
 		replaceInfoLabel.getStyleClass().add("info");
 
-		previousButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.CHEVRON_UP));
-		nextButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.CHEVRON_DOWN));
-		closeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.CLOSE));
+		previousButton.setGraphic(ActionUtils.icon(FontAwesome.CHEVRON_UP));
+		nextButton.setGraphic(ActionUtils.icon(FontAwesome.CHEVRON_DOWN));
+		closeButton.setGraphic(ActionUtils.icon(FontAwesome.TIMES));
 
 		previousButton.setTooltip(new Tooltip(Messages.get(
 			"FindReplacePane.previousButton.tooltip")));
@@ -474,8 +472,7 @@ class FindReplacePane {
 		closeButton.setTooltip(new Tooltip(Messages.get(
 			"FindReplacePane.closeButton.tooltip")));
 
-		findField.setLeft(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.SEARCH));
+		findField.setLeft(ActionUtils.icon(FontAwesome.SEARCH));
 		findField.setRight(nOfHitCountLabel);
 		findField.textProperty().addListener((ov, o, n) -> findAll(true));
 		Nodes.addInputMap(findField, sequence(
@@ -508,8 +505,7 @@ class FindReplacePane {
 
 		replacePane.setVisible(false);
 
-		replaceField.setLeft(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.RETWEET));
+		replaceField.setLeft(ActionUtils.icon(FontAwesome.RETWEET));
 		Nodes.addInputMap(replaceField, sequence(
 			// don't know why, but F3 (set in menubar) does not work if replaceField
 			// has focus

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMarsMetadataTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMarsMetadataTab.java
@@ -37,9 +37,10 @@ import javax.swing.SwingUtilities;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.scijava.Context;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.bdv.MarsBdvFrame;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MetadataEvent;
 import de.mpg.biochem.mars.fx.event.MetadataSelectionChangedEvent;
@@ -232,8 +233,7 @@ public abstract class AbstractMarsMetadataTab<I extends MarsMetadata, C extends 
 		filterField = new CustomTextField();
 		nOfHitCountLabel = new Label();
 
-		filterField.setLeft(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.SEARCH));
+		filterField.setLeft(ActionUtils.icon(FontAwesome.SEARCH));
 		filterField.setRight(nOfHitCountLabel);
 		filterField.getStyleClass().add("find");
 		filterField.textProperty().addListener((observable, oldValue, newValue) -> {

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -70,8 +70,9 @@ import org.scijava.plugin.Parameter;
 import org.scijava.prefs.PrefService;
 import org.scijava.ui.UIService;
 
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import bdv.util.BdvHandle;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
 import de.mpg.biochem.mars.fx.bdv.MarsBdvFrame;
 import de.mpg.biochem.mars.fx.bdv.ViewerTransformSyncStarter;
 import de.mpg.biochem.mars.fx.bdv.ViewerTransformSyncStopper;
@@ -81,6 +82,7 @@ import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveLockEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveSavedEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveSavingEvent;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveUnlockEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeTagsChangedEvent;
 import de.mpg.biochem.mars.fx.event.RefreshMetadataEvent;
@@ -509,12 +511,10 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		showPropertiesButton = new Button("");
 		showPropertiesButton.setStyle(
 			"-fx-background-color: -fx-outer-border, -fx-inner-border, -fx-body-color;-fx-background-insets: 0, 1, 2;-fx-background-radius: 5, 4, 3;");
-		Text caretRight = FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CARET_RIGHT, "1.4em");
-		caretRight.setStyle(caretRight.getStyle() + "-fx-fill: gray;");
-		Text caretLeft = FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CARET_LEFT, "1.4em");
-		caretLeft.setStyle(caretLeft.getStyle() + "-fx-fill: gray;");
+		Text caretRight = ActionUtils.icon(FontAwesome.CARET_RIGHT, "1.4em");
+		caretRight.setStyle(caretRight.getStyle() + "-fx-icon-color: gray;");
+		Text caretLeft = ActionUtils.icon(FontAwesome.CARET_LEFT, "1.4em");
+		caretLeft.setStyle(caretLeft.getStyle() + "-fx-icon-color: gray;");
 		showPropertiesButton.setGraphic(caretRight);
 
 		showPropertiesButton.setOnAction(e -> {

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculesTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculesTab.java
@@ -37,9 +37,10 @@ import javax.swing.SwingUtilities;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.scijava.Context;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.bdv.MarsBdvFrame;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveUnlockEvent;
@@ -409,8 +410,7 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 			}
 		};
 		filterField.setSkin(filterFieldSkin);
-		filterField.setLeft(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.SEARCH));
+		filterField.setLeft(ActionUtils.icon(FontAwesome.SEARCH));
 		filterField.getStyleClass().add("find");
 		filterField.textProperty().addListener((observable, oldValue, newValue) -> {
 			// If we don't clear the selection while we are searching the table will

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractParametersTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractParametersTable.java
@@ -35,8 +35,10 @@ import java.util.LinkedHashMap;
 
 import org.controlsfx.control.textfield.CustomTextField;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.dialogs.RoverErrorDialog;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.EditCell;
 import de.mpg.biochem.mars.molecule.MarsRecord;
 import javafx.application.Platform;
@@ -108,8 +110,7 @@ public abstract class AbstractParametersTable {
 							break;
 						case 2:
 							label.setText("");
-							label.setGraphic(FontAwesomeIconFactory.get().createIcon(
-								de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SQUARE_ALT,
+							label.setGraphic(ActionUtils.icon(FontAwesome.SQUARE_O,
 								"1.1em"));
 							break;
 					}
@@ -139,8 +140,7 @@ public abstract class AbstractParametersTable {
 						return;
 					}
 
-					removeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS, "1.0em"));
+					removeButton.setGraphic(ActionUtils.icon(FontAwesome.MINUS, "1.0em"));
 					removeButton.setCenterShape(true);
 					removeButton.setStyle("-fx-background-radius: 5em; " +
 						"-fx-min-width: 18px; " + "-fx-min-height: 18px; " +
@@ -288,8 +288,7 @@ public abstract class AbstractParametersTable {
 		parameterTable.setEditable(true);
 
 		Button addButton = new Button();
-		addButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS, "1.0em"));
+		addButton.setGraphic(ActionUtils.icon(FontAwesome.PLUS, "1.0em"));
 		addButton.setCenterShape(true);
 		addButton.setCursor(Cursor.DEFAULT);
 		addButton.setStyle("-fx-background-radius: 5em; " +
@@ -353,8 +352,7 @@ public abstract class AbstractParametersTable {
 					break;
 				case 2:
 					typeButton.setText("");
-					typeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SQUARE_ALT,
+					typeButton.setGraphic(ActionUtils.icon(FontAwesome.SQUARE_O,
 						"1.1em"));
 					break;
 			}

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractPositionOfInterestTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractPositionOfInterestTable.java
@@ -37,8 +37,10 @@ import java.util.stream.Collectors;
 
 import org.controlsfx.control.textfield.CustomTextField;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.dialogs.RoverErrorDialog;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.MarsRecord;
@@ -101,8 +103,7 @@ public abstract class AbstractPositionOfInterestTable {
 						return;
 					}
 
-					removeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS, "1.0em"));
+					removeButton.setGraphic(ActionUtils.icon(FontAwesome.MINUS, "1.0em"));
 					removeButton.setCenterShape(true);
 					removeButton.setStyle("-fx-background-radius: 5em; " +
 						"-fx-min-width: 18px; " + "-fx-min-height: 18px; " +
@@ -258,8 +259,7 @@ public abstract class AbstractPositionOfInterestTable {
 		positionTable.setEditable(true);
 
 		Button addButton = new Button();
-		addButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS, "1.0em"));
+		addButton.setGraphic(ActionUtils.icon(FontAwesome.PLUS, "1.0em"));
 		addButton.setCenterShape(true);
 		addButton.setCursor(Cursor.DEFAULT);
 		addButton.setStyle("-fx-background-radius: 5em; " +

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractRegionOfInterestTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractRegionOfInterestTable.java
@@ -37,8 +37,10 @@ import java.util.stream.Collectors;
 
 import org.controlsfx.control.textfield.CustomTextField;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.dialogs.RoverErrorDialog;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.MarsRecord;
@@ -101,8 +103,7 @@ public abstract class AbstractRegionOfInterestTable {
 						return;
 					}
 
-					removeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS, "1.0em"));
+					removeButton.setGraphic(ActionUtils.icon(FontAwesome.MINUS, "1.0em"));
 					removeButton.setCenterShape(true);
 					removeButton.setStyle("-fx-background-radius: 5em; " +
 						"-fx-min-width: 18px; " + "-fx-min-height: 18px; " +
@@ -274,8 +275,7 @@ public abstract class AbstractRegionOfInterestTable {
 		regionTable.setEditable(true);
 
 		Button addButton = new Button();
-		addButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS, "1.0em"));
+		addButton.setGraphic(ActionUtils.icon(FontAwesome.PLUS, "1.0em"));
 		addButton.setCenterShape(true);
 		addButton.setCursor(Cursor.DEFAULT);
 		addButton.setStyle("-fx-background-radius: 5em; " +

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/CommentsTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/CommentsTab.java
@@ -29,28 +29,28 @@
 
 package de.mpg.biochem.mars.fx.molecule;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.BOLD;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CODE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.COPY;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CUT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.EYE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.FILE_CODE_ALT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.HEADER;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.ITALIC;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.LIST_OL;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.LIST_UL;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PASTE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PENCIL;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PRINT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.QUOTE_LEFT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REPEAT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.RETWEET;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SAVE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SEARCH;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.STRIKETHROUGH;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.UNDO;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.BOLD;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.CODE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.COPY;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.CUT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.EYE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.FILE_CODE_O;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.HEADER;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.ITALIC;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.LIST_OL;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.LIST_UL;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.PASTE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.PENCIL;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.PLUS;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.PRINT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.QUOTE_LEFT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.REFRESH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.REPEAT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.RETWEET;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.SAVE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.SEARCH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.STRIKETHROUGH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.UNDO;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,7 +65,6 @@ import java.util.prefs.Preferences;
 import org.apache.commons.io.IOUtils;
 import org.scijava.Context;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
 import de.mpg.biochem.mars.fx.Messages;
 import de.mpg.biochem.mars.fx.dialogs.DocumentTemplateSelectionDialog;
 import de.mpg.biochem.mars.fx.dialogs.RoverErrorDialog;
@@ -292,16 +291,16 @@ public class CommentsTab extends AbstractMoleculeArchiveTab {
 			e -> getActiveSmartEdit().surroundSelection("\n\n> ", ""));
 		Action insertFencedCodeBlockAction = new Action(Messages.get(
 			"MainWindow.insertFencedCodeBlockAction"), "Shortcut+Shift+K",
-			FILE_CODE_ALT, e -> getActiveSmartEdit().surroundSelection("\n\n```\n",
+			FILE_CODE_O, e -> getActiveSmartEdit().surroundSelection("\n\n```\n",
 				"\n```\n\n", Messages.get("MainWindow.insertFencedCodeBlockText")));
 		Action insertHtmlWidgetCodeBlockAction = new Action("Html Widget Code Block", null,
-				FILE_CODE_ALT, e -> getActiveSmartEdit().surroundSelection("\n\n```groovy-html-widget\n",
+				FILE_CODE_O, e -> getActiveSmartEdit().surroundSelection("\n\n```groovy-html-widget\n",
 				"\n```\n\n", loadCommentTemplate("HtmlWidgetTemplate.groovy")));
 		Action insertImageWidgetCodeBlockAction = new Action("Image Widget Code Block", null,
-				FILE_CODE_ALT, e -> getActiveSmartEdit().surroundSelection("\n\n```groovy-image-widget\n",
+				FILE_CODE_O, e -> getActiveSmartEdit().surroundSelection("\n\n```groovy-image-widget\n",
 				"\n```\n\n", loadCommentTemplate("ImageWidgetTemplate.groovy")));
 		Action insertImagesWidgetCodeBlockAction = new Action("Images Widget Code Block", null,
-				FILE_CODE_ALT, e -> getActiveSmartEdit().surroundSelection("\n\n```groovy-images-widget\n",
+				FILE_CODE_O, e -> getActiveSmartEdit().surroundSelection("\n\n```groovy-images-widget\n",
 				"\n```\n\n", loadCommentTemplate("ImagesWidgetTemplate.groovy")));
 		Action insertHeader1Action = new Action(Messages.get(
 			"MainWindow.insertHeader1Action"), "Shortcut+1", HEADER,
@@ -487,8 +486,7 @@ public class CommentsTab extends AbstractMoleculeArchiveTab {
 		editToolBar.getItems().add(0, editModeButton2);
 
 		ButtonBase renderWidgetsButton = new Button();
-		Text renderWidgetsIcon = FontAwesomeIconFactory.get().createIcon(REFRESH,
-			"1.2em");
+		Text renderWidgetsIcon = ActionUtils.icon(REFRESH, "1.2em");
 		renderWidgetsButton.setGraphic(renderWidgetsIcon);
 		renderWidgetsButton.setTooltip(new Tooltip("Render Widgets"));
 		renderWidgetsButton.setFocusTraversable(false);

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/DashboardTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/DashboardTab.java
@@ -38,8 +38,10 @@ import java.util.ArrayList;
 import org.scijava.Context;
 import org.scijava.plugin.Parameter;
 
-import de.jensd.fx.glyphs.materialicons.utils.MaterialIconFactory;
+import org.kordamp.ikonli.material.Material;
+
 import de.mpg.biochem.mars.fx.dashboard.MarsDashboardWidgetService;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.molecule.dashboardTab.MoleculeArchiveDashboard;
@@ -64,8 +66,7 @@ public class DashboardTab extends AbstractMoleculeArchiveTab {
 	public DashboardTab(final Context context) {
 		super(context);
 
-		setIcon(MaterialIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.materialicons.MaterialIcon.DASHBOARD, "1.083em"), "dashboard");
+		setIcon(ActionUtils.icon(Material.DASHBOARD, "1.083em"), "dashboard");
 
 		dashboardPane = new MoleculeArchiveDashboard(context);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/SettingsTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/SettingsTab.java
@@ -29,7 +29,9 @@
 
 package de.mpg.biochem.mars.fx.molecule;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.COG;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.COG;
+
+import org.kordamp.ikonli.fontawesome.FontAwesome;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,8 +43,8 @@ import org.scijava.Context;
 import org.scijava.plugin.Parameter;
 import org.scijava.prefs.PrefService;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.HotKeyEntry;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.Molecule;
@@ -88,7 +90,7 @@ public class SettingsTab extends AbstractMoleculeArchiveTab implements
 	public SettingsTab(final Context context) {
 		super(context);
 
-		setIcon(FontAwesomeIconFactory.get().createIcon(COG, "1.083em"), "settings");
+		setIcon(ActionUtils.icon(COG, "1.083em"), "settings");
 
 		rootPane = new VBox();
 
@@ -180,8 +182,7 @@ public class SettingsTab extends AbstractMoleculeArchiveTab implements
 						return;
 					}
 
-					removeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS, "1.0em"));
+					removeButton.setGraphic(ActionUtils.icon(FontAwesome.MINUS, "1.0em"));
 					removeButton.setCenterShape(true);
 					removeButton.setStyle("-fx-background-radius: 5em; " +
 						"-fx-min-width: 18px; " + "-fx-min-height: 18px; " +
@@ -238,8 +239,7 @@ public class SettingsTab extends AbstractMoleculeArchiveTab implements
 		hotKeyTable.setEditable(true);
 
 		Button addButton = new Button();
-		addButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS, "1.0em"));
+		addButton.setGraphic(ActionUtils.icon(FontAwesome.PLUS, "1.0em"));
 		addButton.setCenterShape(true);
 		addButton.setCursor(Cursor.DEFAULT);
 		addButton.setStyle("-fx-background-radius: 5em; " +

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/dashboardTab/ArchivePropertiesWidget.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/dashboardTab/ArchivePropertiesWidget.java
@@ -29,13 +29,13 @@
 
 package de.mpg.biochem.mars.fx.molecule.dashboardTab;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.INFO_CIRCLE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.INFO_CIRCLE;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.dashboard.AbstractDashboardWidget;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.Molecule;
@@ -77,8 +77,7 @@ public class ArchivePropertiesWidget extends AbstractDashboardWidget implements
 		vbox.setSpacing(5);
 
 		BorderPane iconContainer = new BorderPane();
-		iconContainer.setCenter(FontAwesomeIconFactory.get().createIcon(INFO_CIRCLE,
-			"2em"));
+		iconContainer.setCenter(ActionUtils.icon(INFO_CIRCLE, "2em"));
 
 		vbox.getChildren().add(iconContainer);
 
@@ -134,7 +133,7 @@ public class ArchivePropertiesWidget extends AbstractDashboardWidget implements
 
 	@Override
 	public Node getIcon() {
-		return (Node) FontAwesomeIconFactory.get().createIcon(INFO_CIRCLE, "1.2em");
+		return (Node) ActionUtils.icon(INFO_CIRCLE, "1.2em");
 	}
 
 	@Override

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/dashboardTab/TagFrequencyWidget.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/dashboardTab/TagFrequencyWidget.java
@@ -29,7 +29,7 @@
 
 package de.mpg.biochem.mars.fx.molecule.dashboardTab;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.TAG;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.TAG;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -47,8 +47,8 @@ import io.fair_acc.chartfx.axes.AxisLabelOverlapPolicy;
 import io.fair_acc.chartfx.renderer.LineStyle;
 import io.fair_acc.chartfx.renderer.spi.ErrorDataSetRenderer;
 import io.fair_acc.dataset.spi.DefaultErrorDataSet;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
 import de.mpg.biochem.mars.fx.dashboard.AbstractDashboardWidget;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.plot.tools.MarsNumericAxis;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.Molecule;
@@ -204,7 +204,7 @@ public class TagFrequencyWidget extends AbstractDashboardWidget implements
 
 	@Override
 	public Node getIcon() {
-		return (Node) FontAwesomeIconFactory.get().createIcon(TAG, "1.2em");
+		return (Node) ActionUtils.icon(TAG, "1.2em");
 	}
 
 	@Override

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/AbstractMetadataCenterPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/AbstractMetadataCenterPane.java
@@ -34,13 +34,15 @@ import java.util.HashSet;
 import org.scijava.Context;
 import org.scijava.plugin.Parameter;
 
-import de.jensd.fx.glyphs.materialicons.utils.MaterialIconFactory;
+import org.kordamp.ikonli.material.Material;
+
 import de.mpg.biochem.mars.fx.editor.LogPane;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MetadataEvent;
 import de.mpg.biochem.mars.fx.event.MetadataSelectionChangedEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.molecule.metadataTab.dashboard.MarsMetadataDashboard;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.AbstractJsonConvertibleRecord;
 import javafx.event.Event;
@@ -113,8 +115,7 @@ public abstract class AbstractMetadataCenterPane<I extends MarsMetadata> extends
 
 		marsMetadataDashboardTab = new Tab();
 		marsMetadataDashboardTab.setText("");
-		marsMetadataDashboardTab.setGraphic(MaterialIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.materialicons.MaterialIcon.DASHBOARD, "1.0em"));
+		marsMetadataDashboardTab.setGraphic(ActionUtils.icon(Material.DASHBOARD, "1.0em"));
 		marsMetadataDashboardPane = new MarsMetadataDashboard<I>(context);
 		marsMetadataDashboardTab.setContent(marsMetadataDashboardPane.getNode());
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/AbstractMetadataPropertiesPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/AbstractMetadataPropertiesPane.java
@@ -29,20 +29,22 @@
 
 package de.mpg.biochem.mars.fx.molecule.metadataTab;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.INFO_CIRCLE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.LIST_ALT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.INFO_CIRCLE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.LIST_ALT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.SQUARE_O;
+import static org.kordamp.ikonli.octicons.Octicons.MILESTONE_16;
 
 import com.jfoenix.controls.JFXTabPane;
 
 import javafx.event.EventHandler;
 import org.scijava.Context;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
 import de.mpg.biochem.mars.fx.event.DefaultMoleculeArchiveEventHandler;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MetadataEvent;
 import de.mpg.biochem.mars.fx.event.MetadataSelectionChangedEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.Molecule;
 import de.mpg.biochem.mars.molecule.MoleculeArchive;
@@ -137,8 +139,7 @@ public abstract class AbstractMetadataPropertiesPane<I extends MarsMetadata>
 		// Build general Tab
 		BorderPane tabPane = new BorderPane();
 		tabPane.setMaxWidth(tabWidth);
-		tabPane.setCenter(FontAwesomeIconFactory.get().createIcon(INFO_CIRCLE,
-			"1.1em"));
+		tabPane.setCenter(ActionUtils.icon(INFO_CIRCLE, "1.1em"));
 
 		generalTab = new Tab();
 		generalTabContainer = new AnchorPane();
@@ -159,8 +160,7 @@ public abstract class AbstractMetadataPropertiesPane<I extends MarsMetadata>
 
 		BorderPane propertiesTabPane = new BorderPane();
 		propertiesTabPane.setMaxWidth(tabWidth);
-		propertiesTabPane.setCenter(FontAwesomeIconFactory.get().createIcon(
-			LIST_ALT, "1.1em"));
+		propertiesTabPane.setCenter(ActionUtils.icon(LIST_ALT, "1.1em"));
 
 		propertiesTab = new Tab();
 		propertiesTab.setText("");
@@ -185,8 +185,7 @@ public abstract class AbstractMetadataPropertiesPane<I extends MarsMetadata>
 
 		BorderPane regionsTabPane = new BorderPane();
 		regionsTabPane.setMaxWidth(tabWidth);
-		regionsTabPane.setCenter(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SQUARE_ALT, "1.1em"));
+		regionsTabPane.setCenter(ActionUtils.icon(SQUARE_O, "1.1em"));
 
 		regionsTab = new Tab();
 		regionsTab.setText("");
@@ -211,8 +210,7 @@ public abstract class AbstractMetadataPropertiesPane<I extends MarsMetadata>
 
 		BorderPane positionTabPane = new BorderPane();
 		positionTabPane.setMaxWidth(tabWidth);
-		positionTabPane.setCenter(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.octicons.OctIcon.MILESTONE, "1.1em"));
+		positionTabPane.setCenter(ActionUtils.icon(MILESTONE_16, "1.1em"));
 
 		positionsTab = new Tab();
 		positionsTab.setText("");

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/BdvSourceOptionsPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/BdvSourceOptionsPane.java
@@ -57,7 +57,9 @@ import org.janelia.saalfeldlab.n5.universe.metadata.*;
 import org.janelia.saalfeldlab.n5.universe.metadata.canonical.CanonicalMetadataParser;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadataParser;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.metadata.MarsBdvSource;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
@@ -249,17 +251,14 @@ public class BdvSourceOptionsPane extends VBox {
 		HBox.setHgrow(pathField, Priority.ALWAYS);
 		pathBox.getChildren().add(pathField);
 
-		times = FontAwesomeIconFactory.get().createIcon(
-				de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.TIMES, "1.5em");
-		times.setStyle(times.getStyle() + "-fx-fill: red !important;");
+		times = ActionUtils.icon(FontAwesome.TIMES, "1.5em");
+		times.setStyle(times.getStyle() + "-fx-icon-color: red !important;");
 
-		check = FontAwesomeIconFactory.get().createIcon(
-				de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CHECK, "1.5em");
-		check.setStyle(check.getStyle() + "-fx-fill: green !important;");
+		check = ActionUtils.icon(FontAwesome.CHECK, "1.5em");
+		check.setStyle(check.getStyle() + "-fx-icon-color: green !important;");
 
 		// Spinning refresh icon for the Path field.
-		pathRefresh = FontAwesomeIconFactory.get().createIcon(
-				de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH, "1.5em");
+		pathRefresh = ActionUtils.icon(FontAwesome.REFRESH, "1.5em");
 		pathRefreshSpin = new RotateTransition(Duration.millis(800), pathRefresh);
 		pathRefreshSpin.setByAngle(360);
 		pathRefreshSpin.setCycleCount(RotateTransition.INDEFINITE);
@@ -337,17 +336,14 @@ public class BdvSourceOptionsPane extends VBox {
 		HBox.setMargin(n5Dataset, new Insets(0, 5, 10, 5));
 		n5OptionsHBox.getChildren().add(n5Dataset);
 
-		times2 = FontAwesomeIconFactory.get().createIcon(
-				de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.TIMES, "1.5em");
-		times2.setStyle(times.getStyle() + "-fx-fill: red !important;");
+		times2 = ActionUtils.icon(FontAwesome.TIMES, "1.5em");
+		times2.setStyle(times.getStyle() + "-fx-icon-color: red !important;");
 
-		check2 = FontAwesomeIconFactory.get().createIcon(
-				de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CHECK, "1.5em");
-		check2.setStyle(check.getStyle() + "-fx-fill: green !important;");
+		check2 = ActionUtils.icon(FontAwesome.CHECK, "1.5em");
+		check2.setStyle(check.getStyle() + "-fx-icon-color: green !important;");
 
 		// Spinning refresh icon for the Dataset field.
-		datasetRefresh = FontAwesomeIconFactory.get().createIcon(
-				de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH, "1.5em");
+		datasetRefresh = ActionUtils.icon(FontAwesome.REFRESH, "1.5em");
 		datasetRefreshSpin = new RotateTransition(Duration.millis(800),
 				datasetRefresh);
 		datasetRefreshSpin.setByAngle(360);

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/BdvViewTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/BdvViewTable.java
@@ -41,9 +41,11 @@ import javax.swing.SwingUtilities;
 import de.mpg.biochem.mars.n5.*;
 import org.controlsfx.control.textfield.CustomTextField;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
 import de.mpg.biochem.mars.fx.event.MetadataEvent;
 import de.mpg.biochem.mars.fx.event.MetadataEventHandler;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.EditCell;
 import de.mpg.biochem.mars.metadata.MarsBdvSource;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
@@ -126,8 +128,7 @@ public class BdvViewTable implements MetadataEventHandler {
 						return;
 					}
 
-					removeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS, "1.0em"));
+					removeButton.setGraphic(ActionUtils.icon(FontAwesome.MINUS, "1.0em"));
 					removeButton.setCenterShape(true);
 					removeButton.setStyle("-fx-background-radius: 5em; " +
 						"-fx-min-width: 18px; " + "-fx-min-height: 18px; " +
@@ -197,8 +198,7 @@ public class BdvViewTable implements MetadataEventHandler {
 			bdvIndexTableListener);
 
 		Button addButton = new Button();
-		addButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS, "1.0em"));
+		addButton.setGraphic(ActionUtils.icon(FontAwesome.PLUS, "1.0em"));
 		addButton.setCenterShape(true);
 		addButton.setCursor(Cursor.DEFAULT);
 		addButton.setStyle("-fx-background-radius: 5em; " +

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/MarsOMEView.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/MarsOMEView.java
@@ -40,8 +40,9 @@ import org.scijava.convert.ConvertService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.metadata.GenericModel;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.metadata.MarsOMEImage;
@@ -288,8 +289,7 @@ public class MarsOMEView {
 		BorderPane borderPane = new BorderPane();
 
 		filterField = new CustomTextField();
-		filterField.setLeft(FontAwesomeIconFactory.get().createIcon(
-			FontAwesomeIcon.SEARCH));
+		filterField.setLeft(ActionUtils.icon(FontAwesome.SEARCH));
 		filterField.getStyleClass().add("find");
 		filterField.textProperty().addListener((observable, oldValue, newValue) -> {
 			// If we don't clear the selection while we are searching the table will

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/MetadataGeneralTabController.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/MetadataGeneralTabController.java
@@ -33,7 +33,6 @@ import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXChipView;
 import com.jfoenix.controls.JFXTextField;
 
-import de.jensd.fx.glyphs.octicons.utils.OctIconFactory;
 import de.mpg.biochem.mars.fx.event.DefaultMoleculeArchiveEventHandler;
 import de.mpg.biochem.mars.fx.event.MetadataEvent;
 import de.mpg.biochem.mars.fx.event.MetadataTagsChangedEvent;

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/n5browser/N5DatasetListPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/n5browser/N5DatasetListPane.java
@@ -52,8 +52,9 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.util.Duration;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.scene.text.Text;
 
 /**
@@ -89,8 +90,7 @@ public class N5DatasetListPane extends BorderPane {
     public N5DatasetListPane() {
         setPadding(new Insets(5));
 
-        refresh = FontAwesomeIconFactory.get().createIcon(
-                FontAwesomeIcon.REFRESH, "1.2em");
+        refresh = ActionUtils.icon(FontAwesome.REFRESH, "1.2em");
         refreshSpin = new RotateTransition(Duration.millis(800), refresh);
         refreshSpin.setByAngle(360);
         refreshSpin.setCycleCount(RotateTransition.INDEFINITE);

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/n5browser/N5MinioBrowserDialog.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/n5browser/N5MinioBrowserDialog.java
@@ -59,8 +59,9 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.stage.Window;
 
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 
 /**
  * JavaFX dialog for browsing N5 datasets stored in MinIO/S3 buckets. Lists
@@ -213,8 +214,7 @@ public class N5MinioBrowserDialog extends
                 }
                 else {
                     setText(bucket);
-                    setGraphic(FontAwesomeIconFactory.get().createIcon(
-                            FontAwesomeIcon.ARCHIVE, "1.0em"));
+                    setGraphic(ActionUtils.icon(FontAwesome.ARCHIVE, "1.0em"));
                 }
             }
         });

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/AbstractMoleculeCenterPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/AbstractMoleculeCenterPane.java
@@ -37,7 +37,8 @@ import java.util.Set;
 
 import org.scijava.Context;
 
-import de.jensd.fx.glyphs.materialicons.utils.MaterialIconFactory;
+import org.kordamp.ikonli.material.Material;
+
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveUnlockEvent;
@@ -46,6 +47,7 @@ import de.mpg.biochem.mars.fx.event.MoleculeSelectionChangedEvent;
 import de.mpg.biochem.mars.fx.molecule.moleculesTab.dashboard.MoleculeDashboard;
 import de.mpg.biochem.mars.fx.plot.PlotPane;
 import de.mpg.biochem.mars.fx.plot.event.PlotEvent;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.plot.event.UpdatePlotAreaEvent;
 import de.mpg.biochem.mars.fx.table.MarsTableView;
 import de.mpg.biochem.mars.molecule.AbstractJsonConvertibleRecord;
@@ -97,8 +99,7 @@ public abstract class AbstractMoleculeCenterPane<M extends Molecule, P extends P
 
 		moleculeDashboardTab = new Tab();
 		moleculeDashboardTab.setText("");
-		moleculeDashboardTab.setGraphic(MaterialIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.materialicons.MaterialIcon.DASHBOARD, "1.0em"));
+		moleculeDashboardTab.setGraphic(ActionUtils.icon(Material.DASHBOARD, "1.0em"));
 		moleculeDashboardPane = new MoleculeDashboard<M>(context);
 		moleculeDashboardTab.setContent(moleculeDashboardPane.getNode());
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/AbstractMoleculePropertiesPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/AbstractMoleculePropertiesPane.java
@@ -29,19 +29,21 @@
 
 package de.mpg.biochem.mars.fx.molecule.moleculesTab;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.INFO_CIRCLE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.LIST_ALT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.INFO_CIRCLE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.LIST_ALT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.SQUARE_O;
+import static org.kordamp.ikonli.octicons.Octicons.MILESTONE_16;
 
 import com.jfoenix.controls.JFXTabPane;
 
 import org.scijava.Context;
 import org.scijava.plugin.Parameter;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeSelectionChangedEvent;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.Molecule;
 import de.mpg.biochem.mars.molecule.MoleculeArchive;
@@ -143,8 +145,7 @@ public abstract class AbstractMoleculePropertiesPane<M extends Molecule>
 		// Build general Tab
 		BorderPane tabPane = new BorderPane();
 		tabPane.setMaxWidth(tabWidth);
-		tabPane.setCenter(FontAwesomeIconFactory.get().createIcon(INFO_CIRCLE,
-			"1.1em"));
+		tabPane.setCenter(ActionUtils.icon(INFO_CIRCLE, "1.1em"));
 
 		generalTab = new Tab();
 		generalTab.setText("");
@@ -159,8 +160,7 @@ public abstract class AbstractMoleculePropertiesPane<M extends Molecule>
 
 		BorderPane propertiesTabPane = new BorderPane();
 		propertiesTabPane.setMaxWidth(tabWidth);
-		propertiesTabPane.setCenter(FontAwesomeIconFactory.get().createIcon(
-			LIST_ALT, "1.1em"));
+		propertiesTabPane.setCenter(ActionUtils.icon(LIST_ALT, "1.1em"));
 
 		propertiesTab = new Tab();
 		propertiesTab.setText("");
@@ -185,8 +185,7 @@ public abstract class AbstractMoleculePropertiesPane<M extends Molecule>
 
 		BorderPane regionsTabPane = new BorderPane();
 		regionsTabPane.setMaxWidth(tabWidth);
-		regionsTabPane.setCenter(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SQUARE_ALT, "1.1em"));
+		regionsTabPane.setCenter(ActionUtils.icon(SQUARE_O, "1.1em"));
 
 		regionsTab = new Tab();
 		regionsTab.setText("");
@@ -211,8 +210,7 @@ public abstract class AbstractMoleculePropertiesPane<M extends Molecule>
 
 		BorderPane positionTabPane = new BorderPane();
 		positionTabPane.setMaxWidth(tabWidth);
-		positionTabPane.setCenter(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.octicons.OctIcon.MILESTONE, "1.1em"));
+		positionTabPane.setCenter(ActionUtils.icon(MILESTONE_16, "1.1em"));
 
 		positionsTab = new Tab();
 		positionsTab.setText("");

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/MoleculeGeneralTabController.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/MoleculeGeneralTabController.java
@@ -33,11 +33,12 @@ import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXChipView;
 import com.jfoenix.controls.JFXTextField;
 
-import de.jensd.fx.glyphs.materialicons.utils.MaterialIconFactory;
-import de.jensd.fx.glyphs.octicons.utils.OctIconFactory;
+import org.kordamp.ikonli.material.Material;
+
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeTagsChangedEvent;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.MarsJFXChipViewSkin;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import de.mpg.biochem.mars.molecule.Molecule;
@@ -105,8 +106,7 @@ public class MoleculeGeneralTabController implements MoleculeSubPane {
 		UIDIconContainer = new BorderPane();
 		UIDIconContainer.setPrefHeight(55.0);
 		UIDIconContainer.setPrefWidth(60.0);
-		UIDIconContainer.setCenter(MaterialIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.materialicons.MaterialIcon.FINGERPRINT, "2.5em"));
+		UIDIconContainer.setCenter(ActionUtils.icon(Material.FINGERPRINT, "2.5em"));
 		vBox.getChildren().add(UIDIconContainer);
 
 		UIDLabel = new Label();

--- a/src/main/java/de/mpg/biochem/mars/fx/plot/AbstractMoleculePlotPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/plot/AbstractMoleculePlotPane.java
@@ -29,7 +29,7 @@
 
 package de.mpg.biochem.mars.fx.plot;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.SQUARE_ALT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.SQUARE_O;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.core.JsonToken;
@@ -131,7 +131,7 @@ public abstract class AbstractMoleculePlotPane<M extends Molecule, S extends Sub
 
 		regionSelected = new SimpleBooleanProperty();
 		Action regionSelectionCursor = new Action("region", "Shortcut+R",
-			SQUARE_ALT, e -> setTool(regionSelected, () -> {
+			SQUARE_O, e -> setTool(regionSelected, () -> {
 				MarsRegionSelectionPlugin tool = new MarsRegionSelectionPlugin(
 					AxisMode.X);
 				return tool;
@@ -140,7 +140,7 @@ public abstract class AbstractMoleculePlotPane<M extends Molecule, S extends Sub
 
 		positionSelected = new SimpleBooleanProperty();
 		Action positionSelectionCursor = new Action("position", "Shortcut+P",
-			de.jensd.fx.glyphs.octicons.OctIcon.MILESTONE, e -> setTool(
+			org.kordamp.ikonli.octicons.Octicons.MILESTONE_24, e -> setTool(
 				positionSelected, () -> {
 					MarsPositionSelectionPlugin tool = new MarsPositionSelectionPlugin();
 					return tool;

--- a/src/main/java/de/mpg/biochem/mars/fx/plot/AbstractPlotPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/plot/AbstractPlotPane.java
@@ -29,17 +29,17 @@
 
 package de.mpg.biochem.mars.fx.plot;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.ARROWS;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.ARROWS_H;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.ARROWS_V;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.CIRCLE_ALT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.COG;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.EXPAND;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.HAND_PAPER_ALT;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.IMAGE;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS;
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.ARROWS;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.ARROWS_H;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.ARROWS_V;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.CIRCLE_O;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.COG;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.EXPAND;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.HAND_PAPER_O;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.IMAGE;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.MINUS;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.PLUS;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.REFRESH;
 
 import java.io.File;
 import java.io.IOException;
@@ -207,7 +207,7 @@ public abstract class AbstractPlotPane extends AbstractJsonConvertibleRecord
 
 	protected void buildTools() {
 
-		Action trackCursor = new Action("Track", null, CIRCLE_ALT, e -> setTool(
+		Action trackCursor = new Action("Track", null, CIRCLE_O, e -> setTool(
 			trackSelected, () -> new MarsDataPointTracker(), Cursor.DEFAULT), null,
 			trackSelected);
 		addTool(trackCursor);
@@ -227,7 +227,7 @@ public abstract class AbstractPlotPane extends AbstractJsonConvertibleRecord
 				Cursor.V_RESIZE), null, zoomYSelected);
 		addTool(zoomYCursor);
 
-		Action panCursor = new Action("Pan", null, HAND_PAPER_ALT, e -> setTool(
+		Action panCursor = new Action("Pan", null, HAND_PAPER_O, e -> setTool(
 			panSelected, () -> {
 				MarsPanner panner = new MarsPanner();
 				//panner.setPanMouseFilter(PAN_MOUSE_FILTER);

--- a/src/main/java/de/mpg/biochem/mars/fx/plot/AbstractSubPlot.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/plot/AbstractSubPlot.java
@@ -29,7 +29,7 @@
 
 package de.mpg.biochem.mars.fx.plot;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.LINE_CHART;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.LINE_CHART;
 
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/de/mpg/biochem/mars/fx/plot/DatasetOptionsPane.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/plot/DatasetOptionsPane.java
@@ -29,7 +29,7 @@
 
 package de.mpg.biochem.mars.fx.plot;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.REFRESH;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.REFRESH;
 import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
@@ -42,8 +42,8 @@ import com.jfoenix.controls.JFXColorPicker;
 import com.jfoenix.controls.JFXTextField;
 
 import io.fair_acc.chartfx.XYChart;
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
-import de.jensd.fx.glyphs.octicons.utils.OctIconFactory;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+import de.mpg.biochem.mars.fx.util.ActionUtils;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -259,8 +259,7 @@ public class DatasetOptionsPane extends VBox {
 						return;
 					}
 
-					removeButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-						de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.MINUS, "1.0em"));
+					removeButton.setGraphic(ActionUtils.icon(FontAwesome.MINUS, "1.0em"));
 					removeButton.setCenterShape(true);
 					removeButton.setStyle("-fx-background-radius: 5em; " +
 						"-fx-min-width: 18px; " + "-fx-min-height: 18px; " +
@@ -376,8 +375,7 @@ public class DatasetOptionsPane extends VBox {
 		plotPropertiesTable.setItems(plotSeriesList);
 
 		addButton = new Button();
-		addButton.setGraphic(FontAwesomeIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.PLUS, "1.0em"));
+		addButton.setGraphic(ActionUtils.icon(FontAwesome.PLUS, "1.0em"));
 		addButton.setCenterShape(true);
 		addButton.setStyle("-fx-background-radius: 5em; " +
 			"-fx-min-width: 20px; " + "-fx-min-height: 20px; " +
@@ -389,7 +387,7 @@ public class DatasetOptionsPane extends VBox {
 			}
 		});
 
-		Text syncIcon = OctIconFactory.get().createIcon(REFRESH, "1.0em");
+		Text syncIcon = ActionUtils.icon(REFRESH, "1.0em");
 		updateButton = new Button();
 		updateButton.setGraphic(syncIcon);
 		updateButton.setCenterShape(true);

--- a/src/main/java/de/mpg/biochem/mars/fx/table/MarsTableFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/table/MarsTableFxFrame.java
@@ -29,7 +29,7 @@
 
 package de.mpg.biochem.mars.fx.table;
 
-import static de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.FLOPPY_ALT;
+import static org.kordamp.ikonli.fontawesome.FontAwesome.FLOPPY_O;
 
 import java.awt.Rectangle;
 import java.io.BufferedInputStream;
@@ -57,7 +57,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
-import de.jensd.fx.glyphs.materialicons.utils.MaterialIconFactory;
+import org.kordamp.ikonli.material.Material;
+
 import de.mpg.biochem.mars.fx.dashboard.MarsDashboardWidgetService;
 import de.mpg.biochem.mars.fx.plot.MarsTablePlotPane;
 import de.mpg.biochem.mars.fx.table.dashboard.MarsTableDashboard;
@@ -212,7 +213,7 @@ public class MarsTableFxFrame extends AbstractJsonConvertibleRecord implements
 
 	protected MenuBar buildMenuBar() {
 		Action fileSaveAsYAMTAction = new Action("Save as YAMT", "Shortcut+S",
-			FLOPPY_ALT, e -> save());
+			FLOPPY_O, e -> save());
 		Action fileSaveAsCSVAction = new Action("Export to CSV", "Shortcut+C", null,
 			e -> saveAsCSV());
 		Action fileSaveAsJSONAction = new Action("Export to JSON", "Shortcut+C",
@@ -248,8 +249,7 @@ public class MarsTableFxFrame extends AbstractJsonConvertibleRecord implements
 
 		dashboardTab = new Tab();
 		dashboardTab.setText("");
-		dashboardTab.setGraphic(MaterialIconFactory.get().createIcon(
-			de.jensd.fx.glyphs.materialicons.MaterialIcon.DASHBOARD, "1.2em"));
+		dashboardTab.setGraphic(ActionUtils.icon(Material.DASHBOARD, "1.2em"));
 		marsTableDashboardPane = new MarsTableDashboard(context, table);
 		dashboardTab.setContent(marsTableDashboardPane.getNode());
 

--- a/src/main/java/de/mpg/biochem/mars/fx/util/Action.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/util/Action.java
@@ -55,7 +55,7 @@
 
 package de.mpg.biochem.mars.fx.util;
 
-import de.jensd.fx.glyphs.GlyphIcons;
+import org.kordamp.ikonli.Ikon;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.event.ActionEvent;
@@ -71,24 +71,24 @@ public class Action {
 
 	public final String text;
 	public final KeyCombination accelerator;
-	public final GlyphIcons icon;
+	public final Ikon icon;
 	public final EventHandler<ActionEvent> action;
 	public final ObservableBooleanValue disable;
 	public final BooleanProperty selected;
 
-	public Action(String text, String accelerator, GlyphIcons icon,
+	public Action(String text, String accelerator, Ikon icon,
 		EventHandler<ActionEvent> action)
 	{
 		this(text, accelerator, icon, action, null, null);
 	}
 
-	public Action(String text, String accelerator, GlyphIcons icon,
+	public Action(String text, String accelerator, Ikon icon,
 		EventHandler<ActionEvent> action, ObservableBooleanValue disable)
 	{
 		this(text, accelerator, icon, action, disable, null);
 	}
 
-	public Action(String text, String accelerator, GlyphIcons icon,
+	public Action(String text, String accelerator, Ikon icon,
 		EventHandler<ActionEvent> action, ObservableBooleanValue disable,
 		BooleanProperty selected)
 	{

--- a/src/main/java/de/mpg/biochem/mars/fx/util/ActionUtils.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/util/ActionUtils.java
@@ -55,7 +55,8 @@
 
 package de.mpg.biochem.mars.fx.util;
 
-import de.jensd.fx.glyphs.fontawesome.utils.FontAwesomeIconFactory;
+import org.kordamp.ikonli.Ikon;
+import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.beans.property.BooleanProperty;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -95,8 +96,7 @@ public class ActionUtils {
 		MenuItem menuItem = (action.selected != null) ? new CheckMenuItem(
 			action.text) : new MenuItem(action.text);
 		if (action.accelerator != null) menuItem.setAccelerator(action.accelerator);
-		if (action.icon != null) menuItem.setGraphic(FontAwesomeIconFactory.get()
-			.createIcon(action.icon));
+		if (action.icon != null) menuItem.setGraphic(icon(action.icon));
 		if (action.action != null) menuItem.setOnAction(action.action);
 		if (action.disable != null) menuItem.disableProperty().bind(action.disable);
 		if (action.selected != null) ((CheckMenuItem) menuItem).selectedProperty()
@@ -132,8 +132,7 @@ public class ActionUtils {
 	public static ButtonBase createToolBarButton(Action action, String size) {
 		ButtonBase button = (action.selected != null) ? new ToggleButton()
 			: new Button();
-		button.setGraphic(FontAwesomeIconFactory.get().createIcon(action.icon,
-			size));
+		button.setGraphic(icon(action.icon, size));
 		String tooltip = action.text;
 		if (tooltip.endsWith("...")) tooltip = tooltip.substring(0, tooltip
 			.length() - 3);
@@ -162,5 +161,20 @@ public class ActionUtils {
 		if (selected != null) ((ToggleButton) button).selectedProperty()
 			.bindBidirectional(selected);
 		return button;
+	}
+
+	public static FontIcon icon(Ikon icon) {
+		return new FontIcon(icon);
+	}
+
+	public static FontIcon icon(Ikon icon, String emSize) {
+		FontIcon fontIcon = new FontIcon(icon);
+		fontIcon.setIconSize(emToPx(emSize));
+		return fontIcon;
+	}
+
+	private static int emToPx(String em) {
+		double value = Double.parseDouble(em.replace("em", "").trim());
+		return (int) Math.round(value * 16);
 	}
 }

--- a/src/main/resources/de/mpg/biochem/mars/fx/styles/components/dialogs.css
+++ b/src/main/resources/de/mpg/biochem/mars/fx/styles/components/dialogs.css
@@ -67,8 +67,10 @@
     -fx-padding: 0 0.5em 0 0.25em;
 }
 
-.find-replace .custom-text-field .glyph-icon {
+.find-replace .custom-text-field .glyph-icon,
+.find-replace .custom-text-field .ikonli-font-icon {
     -fx-fill: #aaa;
+    -fx-icon-color: #aaa;
 }
 
 .find-replace .custom-text-field .label {

--- a/src/main/resources/de/mpg/biochem/mars/fx/styles/components/icons.css
+++ b/src/main/resources/de/mpg/biochem/mars/fx/styles/components/icons.css
@@ -167,6 +167,7 @@
 [class*="icon-"] {
     -fx-fill: -icon-paint !important;
     -fx-text-fill: -icon-paint !important;
+    -fx-icon-color: -icon-paint !important;
     -fx-effect: null !important;
 }
 

--- a/src/main/resources/de/mpg/biochem/mars/fx/styles/components/text-controls.css
+++ b/src/main/resources/de/mpg/biochem/mars/fx/styles/components/text-controls.css
@@ -41,8 +41,10 @@
     -fx-padding: 0 0.5em 0 0.25em;
 }
 
-.custom-text-field .glyph-icon {
+.custom-text-field .glyph-icon,
+.custom-text-field .ikonli-font-icon {
     -fx-fill: #aaa;
+    -fx-icon-color: #aaa;
 }
 
 .custom-text-field .label {

--- a/src/main/resources/de/mpg/biochem/mars/fx/styles/themes/dark-theme.css
+++ b/src/main/resources/de/mpg/biochem/mars/fx/styles/themes/dark-theme.css
@@ -498,6 +498,7 @@ Text, .text {
 [class*="icon-"] {
     -fx-fill: -mars-dark-text-primary !important;
     -fx-text-fill: -mars-dark-text-primary !important;
+    -fx-icon-color: -mars-dark-text-primary !important;
     -fx-effect: null !important;
 }
 

--- a/src/main/resources/de/mpg/biochem/mars/fx/styles/themes/light-theme.css
+++ b/src/main/resources/de/mpg/biochem/mars/fx/styles/themes/light-theme.css
@@ -236,15 +236,6 @@
     -fx-effect: dropshadow(three-pass-box, rgba(0, 123, 255, 0.25), 4, 0, 0, 0);
 }
 
-/* Validation icons */
-.bdv-source-options .label .fontawesome-icon.fa-times {
-    -fx-fill: #dc3545 !important; /* Red color for X icon */
-}
-
-.bdv-source-options .label .fontawesome-icon.fa-check {
-    -fx-fill: #28a745 !important; /* Green color for check icon */
-}
-
 /* Button styling */
 .bdv-source-options .button {
     -fx-background-color: #f8f9fa;


### PR DESCRIPTION
FontAwesomeFX (de.jensd:fontawesomefx-*) is unmaintained; replace it with Ikonli, which provides equivalent FontAwesome/Material/Octicons icon packs behind a single unified FontIcon/Ikon API.

- pom.xml: swap the 5 fontawesomefx-* dependencies for ikonli-javafx, ikonli-fontawesome-pack, ikonli-material-pack, ikonli-octicons-pack.
- Action/ActionUtils: GlyphIcons -> Ikon, add icon()/icon(Ikon, String) helpers centralizing FontIcon construction and em->px sizing so every call site stays a single expression.
- Rename the FontAwesomeFX "_ALT"/"CLOSE" icon constants to Ikonli's "_O"/"TIMES" equivalents (CIRCLE_ALT->CIRCLE_O, FILE_ALT->FILE_O, FOLDER_ALT->FOLDER_OPEN_O, etc.) across all call sites, and correct a few call sites that were routing FontAwesome constants through OctIconFactory/MaterialIconFactory (which worked only because the old library's factories are interchangeable glyph renderers).
- Octicons now require a size-suffixed constant (_16/_24); pick per call site based on the existing em size.
- Switch imperative icon recoloring from -fx-fill to -fx-icon-color (BdvSourceOptionsPane, AbstractMoleculeArchiveFxFrame), and add -fx-icon-color alongside -fx-fill in the shared CSS icon rules. Delete the now-dead .fa-times/.fa-check rules in light-theme.css, which targeted FontAwesomeFX's auto-generated per-icon classes that Ikonli never produces.

Verified with a full clean `mvn compile` and a throwaway JavaFX harness rendering every icon pattern (both packs, all size buckets, renamed icons, recolored icons, toolbar buttons) in light and dark themes.