### PR TITLE
Fix NPE when opening Dataset Explorer window

### DIFF
--- a/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/explorer/DatasetExplorerWindow.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dialogs/s3/explorer/DatasetExplorerWindow.java
@@ -1237,7 +1237,7 @@ public class DatasetExplorerWindow {
     private void tryLoadCachedIndex() {
         String endpoint = sourceEndpoint();
         String bucket = sourceBucket();
-        String folder = indexFolderField.getText().trim();
+        String folder = indexFolderField == null ? "" : indexFolderField.getText().trim();
         if (endpoint.isEmpty() || bucket.isEmpty() || folder.isEmpty()) return;
         store = new DatasetIndexStore(folder);
         try {


### PR DESCRIPTION
tryLoadCachedIndex() is invoked by selection listeners that fire synchronously during buildLeftPane() (tab selection, bucket-list pre-selection), but indexFolderField isn't constructed until buildRightPane() runs afterward. Guard the field like the existing null checks for localPathField in the same method.