### PR TITLE
Add read-ahead molecule record cache with background I/O

### DIFF
--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -366,6 +366,15 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		settingsTab = new SettingsTab(context);
 		tabSet.add(settingsTab);
 
+		// Push cache size preference changes straight into the live cache so
+		// they take effect without reopening the archive.
+		settingsTab.getCacheLookAheadSpinner().valueProperty().addListener(
+			(obs, oldValue, newValue) -> moleculesTab.setCacheLookAhead(
+				newValue));
+		settingsTab.getCacheLookBehindSpinner().valueProperty().addListener(
+			(obs, oldValue, newValue) -> moleculesTab.setCacheLookBehind(
+				newValue));
+
 		// fire save events for tabs as they are left and update events for new tabs
 		tabsContainer.getSelectionModel().selectedItemProperty().addListener(
 			new ChangeListener<Tab>()

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculesTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculesTab.java
@@ -104,6 +104,8 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 
 	protected FilteredList<MoleculeIndexRow> filteredData;
 
+	protected MoleculeRecordCache cache;
+
 	protected MarsBdvFrame[] marsBdvFrames;
 
 	protected ChangeListener<MoleculeIndexRow> moleculeIndexTableListener;
@@ -194,10 +196,13 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 						"REFRESH_MOLECULE_EVENT"))
 					{
 						// Reload molecule due to changes in the virtual store copy on the
-						// disk..
+						// disk.. Invalidate first, or the cache would just return the
+						// stale retained instance and the refresh would silently do
+						// nothing.
 						if (molecule == null) return;
-						molecule = (M) archive.get(molecule.getUID());
-		
+						cache.invalidate(molecule.getUID());
+						molecule = (M) cache.get(molecule.getUID());
+
 						moleculeCenterPane.fireEvent(new MoleculeSelectionChangedEvent(
 							molecule));
 						moleculePropertiesPane.fireEvent(new MoleculeSelectionChangedEvent(
@@ -359,12 +364,15 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 				MoleculeIndexRow oldMoleculeIndexRow,
 				MoleculeIndexRow newMoleculeIndexRow)
 			{
-				// Need to save the current record when we change in the case the
-				// virtual storage.
-				saveCurrentRecord();
+				// Save the outgoing record (asynchronously, via the cache) only if
+				// it actually changed. Capture it before reassigning molecule below
+				// so the I/O thread never races the GUI thread's in-place edits.
+				M outgoing = molecule;
+				if (outgoing != null && outgoing.isModified()) cache.saveAsync(
+					outgoing);
 
 				if (newMoleculeIndexRow != null) {
-					molecule = (M) archive.get(newMoleculeIndexRow.getUID());
+					molecule = (M) cache.get(newMoleculeIndexRow.getUID());
 
 					// Here is an opportunity to update global indexes based
 					archive.properties().addMoleculeProperties(molecule);
@@ -390,6 +398,9 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 					Platform.runLater(() -> {
 						moleculeIndexTable.requestFocus();
 					});
+
+					cache.updateWindow(visibleMoleculeUIDs(), moleculeIndexTable
+						.getSelectionModel().getSelectedIndex());
 				}
 			}
 		};
@@ -522,13 +533,43 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 
 		moleculeCenterPane.fireEvent(new InitializeMoleculeArchiveEvent(archive));
 		moleculePropertiesPane.fireEvent(new InitializeMoleculeArchiveEvent(archive));
+
+		// Flushes any dirty records before the cache is torn down or replaced,
+		// so switching or closing an archive never silently drops an edit.
+		if (cache != null) cache.shutdown();
+
 		if (archive == null) {
+			cache = null;
 			molecule = null;
 			moleculeCenterPane.fireEvent(new MoleculeSelectionChangedEvent(null));
 			moleculePropertiesPane.fireEvent(new MoleculeSelectionChangedEvent(null));
 			return;
 		}
+
+		cache = new MoleculeRecordCache(archive);
+		cache.setLookAhead(prefService.getInt(SettingsTab.class,
+			"recordCacheLookAhead", 10));
+		cache.setLookBehind(prefService.getInt(SettingsTab.class,
+			"recordCacheLookBehind", 3));
+
 		onMoleculeArchiveUnlockEvent();
+	}
+
+	@Override
+	public void setCacheLookAhead(int lookAhead) {
+		if (cache != null) cache.setLookAhead(lookAhead);
+	}
+
+	@Override
+	public void setCacheLookBehind(int lookBehind) {
+		if (cache != null) cache.setLookBehind(lookBehind);
+	}
+
+	private List<String> visibleMoleculeUIDs() {
+		List<String> uids = new ArrayList<>(filteredData.size());
+		for (MoleculeIndexRow row : filteredData)
+			uids.add(row.getUID());
+		return uids;
 	}
 
 	@Override
@@ -646,6 +687,9 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 
 	@Override
 	public void onMoleculeArchiveLockEvent() {
+		// Any queued async save must land before a script/command/save runs
+		// against the store, so block here until the cache is fully flushed.
+		if (cache != null) cache.flushAndWait();
 		saveCurrentRecord();
 	}
 
@@ -654,6 +698,13 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 	public void onMoleculeArchiveUnlockEvent() {
 		moleculeIndexTable.getSelectionModel().selectedItemProperty()
 			.removeListener(moleculeIndexTableListener);
+
+		// Records on disk may have changed under a bulk operation that just ran
+		// under the archive lock (which already flushed anything dirty here via
+		// onMoleculeArchiveLockEvent), so discard retained instances rather than
+		// risk showing a stale one.
+		if (cache != null) cache.invalidateAll();
+
 		//Check if the current molecule was deleted, if so set molecule = null
 		if (molecule != null && !archive.contains(molecule.getUID())) {
 			molecule = null; 
@@ -694,13 +745,14 @@ public abstract class AbstractMoleculesTab<M extends Molecule, C extends Molecul
 
 			if (filteredData.size() > 0) {
 				moleculeIndexTable.getSelectionModel().select(newIndex);
-				molecule = (M) archive.get(moleculeIndexTable.getSelectionModel()
+				molecule = (M) cache.get(moleculeIndexTable.getSelectionModel()
 					.getSelectedItem().getUID());
 				moleculeCenterPane.fireEvent(new MoleculeArchiveUnlockEvent(archive));
 				moleculeCenterPane.fireEvent(new MoleculeSelectionChangedEvent(
 					molecule));
 				moleculePropertiesPane.fireEvent(new MoleculeSelectionChangedEvent(
 					molecule));
+				cache.updateWindow(visibleMoleculeUIDs(), newIndex);
 			}
 		}
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/MoleculeRecordCache.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/MoleculeRecordCache.java
@@ -1,0 +1,270 @@
+/*-
+ * #%L
+ * JavaFX GUI for processing single-molecule TIRF and FMT data in the Structure and Dynamics of Molecular Machines research group.
+ * %%
+ * Copyright (C) 2018 - 2026 Karl Duderstadt
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package de.mpg.biochem.mars.fx.molecule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import de.mpg.biochem.mars.metadata.MarsMetadata;
+import de.mpg.biochem.mars.molecule.Molecule;
+import de.mpg.biochem.mars.molecule.MoleculeArchive;
+import de.mpg.biochem.mars.molecule.MoleculeArchiveIndex;
+import de.mpg.biochem.mars.molecule.MoleculeArchiveProperties;
+
+/**
+ * Retains molecule records loaded from a virtual archive around the current
+ * selection, so {@link AbstractMoleculesTab} does not re-parse and re-write an
+ * unchanged record on every selection change. Reads and writes run on a single
+ * background thread so the FX thread never blocks on virtual store I/O.
+ * <p>
+ * Bypassed entirely for in-memory archives: {@code archive.get}/{@code put}
+ * are already O(1) there and already retain a single instance per UID, so the
+ * cache would only add a second identity for the same record.
+ * </p>
+ * <p>
+ * Object identity is the load-bearing invariant here: the GUI mutates the
+ * molecule it holds in place (tag hotkeys, notes editor, parameters table,
+ * region/position handlers), so {@link #get(String)} must always return the
+ * same retained instance for a UID as long as anything might still reference
+ * it. A prefetch must never replace an already-cached instance.
+ * </p>
+ * All public methods are called from the FX thread. Only the I/O executor
+ * thread touches {@code archive.get}/{@code archive.put}.
+ */
+public class MoleculeRecordCache {
+
+	private final MoleculeArchive<Molecule, MarsMetadata, MoleculeArchiveProperties<Molecule, MarsMetadata>, MoleculeArchiveIndex<Molecule, MarsMetadata>> archive;
+
+	private final boolean virtual;
+
+	// Synchronized because get()/prefetch tasks touch it from both the FX
+	// thread and the I/O thread. Iteration (updateWindow, flushAndWait) must
+	// hold the monitor manually per the Collections.synchronizedMap contract.
+	private final Map<String, Molecule> cache = Collections.synchronizedMap(
+		new LinkedHashMap<>());
+
+	private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+
+	private final ExecutorService ioExecutor = Executors
+		.newSingleThreadExecutor(r -> {
+			Thread t = new Thread(r, "Mars-record-io");
+			t.setDaemon(true);
+			return t;
+		});
+
+	private volatile int lookAhead = 10;
+	private volatile int lookBehind = 3;
+	private volatile String selectedUID;
+
+	public MoleculeRecordCache(
+		MoleculeArchive<Molecule, MarsMetadata, MoleculeArchiveProperties<Molecule, MarsMetadata>, MoleculeArchiveIndex<Molecule, MarsMetadata>> archive)
+	{
+		this.archive = archive;
+		this.virtual = archive.isVirtual();
+	}
+
+	public void setLookAhead(int lookAhead) {
+		this.lookAhead = Math.max(0, lookAhead);
+	}
+
+	public void setLookBehind(int lookBehind) {
+		this.lookBehind = Math.max(0, lookBehind);
+	}
+
+	/**
+	 * FX thread. Fast path on a cache hit; blocking deserialize on a miss (same
+	 * cost as {@code archive.get} today).
+	 */
+	public Molecule get(String uid) {
+		if (!virtual) return archive.get(uid);
+		if (uid == null) return null;
+
+		Molecule molecule = cache.get(uid);
+		if (molecule != null) return molecule;
+
+		molecule = archive.get(uid);
+		if (molecule != null) cache.put(uid, molecule);
+		return molecule;
+	}
+
+	/**
+	 * FX thread, returns immediately. Only call this for a record known to be
+	 * dirty ({@code isModified()}); the write happens on the I/O thread.
+	 */
+	public void saveAsync(Molecule molecule) {
+		if (molecule == null) return;
+		if (!virtual) {
+			// put() still maintains indexes/properties for in-memory archives,
+			// and is already effectively free, so just do it directly.
+			archive.put(molecule);
+			return;
+		}
+
+		String uid = molecule.getUID();
+		inFlight.add(uid);
+		ioExecutor.submit(() -> {
+			try {
+				archive.put(molecule);
+			}
+			finally {
+				inFlight.remove(uid);
+			}
+		});
+	}
+
+	/**
+	 * FX thread, returns immediately. Schedules prefetching of the window
+	 * around {@code selectedIndex} and evicts anything now outside it.
+	 * {@code visibleUIDs} must be in the same order the user scrolls, i.e. the
+	 * filtered/visible list, not necessarily archive order.
+	 */
+	public void updateWindow(List<String> visibleUIDs, int selectedIndex) {
+		if (!virtual) return;
+		if (visibleUIDs == null || visibleUIDs.isEmpty()) return;
+
+		selectedUID = (selectedIndex >= 0 &&
+			selectedIndex < visibleUIDs.size()) ? visibleUIDs.get(
+				selectedIndex) : null;
+
+		int start = Math.max(0, selectedIndex - lookBehind);
+		int end = Math.min(visibleUIDs.size(), selectedIndex + lookAhead + 1);
+
+		Set<String> targetWindow = new LinkedHashSet<>();
+		for (int i = start; i < end; i++)
+			targetWindow.add(visibleUIDs.get(i));
+
+		evictOutside(targetWindow);
+		prefetch(targetWindow);
+	}
+
+	private void evictOutside(Set<String> targetWindow) {
+		List<String> toEvict = new ArrayList<>();
+		synchronized (cache) {
+			for (String uid : cache.keySet()) {
+				if (uid.equals(selectedUID)) continue;
+				if (!targetWindow.contains(uid)) toEvict.add(uid);
+			}
+		}
+
+		for (String uid : toEvict) {
+			Molecule molecule = cache.remove(uid);
+			// A save already queued for this UID holds its own reference to the
+			// molecule and will complete correctly even after the map entry is
+			// gone, so skip queuing a redundant duplicate write.
+			if (molecule != null && molecule.isModified() && !inFlight.contains(
+				uid)) saveAsync(molecule);
+		}
+	}
+
+	private void prefetch(Set<String> targetWindow) {
+		for (String uid : targetWindow) {
+			// The selected UID is always loaded synchronously via get() before
+			// updateWindow is called.
+			if (uid.equals(selectedUID)) continue;
+			if (cache.containsKey(uid) || inFlight.contains(uid)) continue;
+
+			inFlight.add(uid);
+			ioExecutor.submit(() -> {
+				try {
+					// Re-check inside the task: prefetching an already-cached UID
+					// must never replace the retained instance with a fresh parse,
+					// since that would discard any in-place edits made meanwhile.
+					if (!cache.containsKey(uid)) {
+						Molecule molecule = archive.get(uid);
+						if (molecule != null) cache.put(uid, molecule);
+					}
+				}
+				finally {
+					inFlight.remove(uid);
+				}
+			});
+		}
+	}
+
+	/**
+	 * Drop a single cached UID, e.g. immediately before an explicit re-read
+	 * from disk that must not be masked by a stale retained instance.
+	 */
+	public void invalidate(String uid) {
+		cache.remove(uid);
+	}
+
+	/**
+	 * Discard every cached entry without saving. Only safe to call right after
+	 * {@link #flushAndWait()} has already run (e.g. following a bulk operation
+	 * that owns the data and ran under the archive lock).
+	 */
+	public void invalidateAll() {
+		cache.clear();
+		selectedUID = null;
+	}
+
+	/**
+	 * Blocks the calling thread until every queued read/write completes, then
+	 * synchronously saves anything still dirty in the cache. Called from
+	 * lock/close paths where a brief block is acceptable; never call this from
+	 * the selection listener.
+	 */
+	public void flushAndWait() {
+		if (!virtual) return;
+
+		CountDownLatch drained = new CountDownLatch(1);
+		ioExecutor.submit(drained::countDown);
+		try {
+			drained.await();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+
+		List<Molecule> dirty = new ArrayList<>();
+		synchronized (cache) {
+			for (Molecule molecule : cache.values())
+				if (molecule.isModified()) dirty.add(molecule);
+		}
+		for (Molecule molecule : dirty)
+			archive.put(molecule);
+	}
+
+	/** Flushes dirty records, then stops the I/O thread. */
+	public void shutdown() {
+		flushAndWait();
+		ioExecutor.shutdown();
+	}
+}

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/MoleculesTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/MoleculesTab.java
@@ -50,4 +50,10 @@ public interface MoleculesTab<C extends MoleculeSubPane, O extends MoleculeSubPa
 	public void setSelectedMolecule(Molecule molecule);
 
 	public void setMarsBdvFrames(MarsBdvFrame[] marsBdvFrames);
+
+	/** Records ahead of the selection to prefetch. 0 disables prefetching. */
+	public void setCacheLookAhead(int lookAhead);
+
+	/** Records behind the selection to prefetch. 0 disables prefetching. */
+	public void setCacheLookBehind(int lookBehind);
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/SettingsTab.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/SettingsTab.java
@@ -60,6 +60,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
+import javafx.scene.control.Spinner;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -86,6 +87,9 @@ public class SettingsTab extends AbstractMoleculeArchiveTab implements
 		.observableArrayList();
 
 	private VBox rootPane;
+
+	private Spinner<Integer> cacheLookAheadSpinner;
+	private Spinner<Integer> cacheLookBehindSpinner;
 
 	public SettingsTab(final Context context) {
 		super(context);
@@ -148,6 +152,41 @@ public class SettingsTab extends AbstractMoleculeArchiveTab implements
 			prefService.put(SettingsTab.class, "activateSynchronizedBdvWindows", n);
 		});
 		GridPane.setMargin(synBdvSwitch, new Insets(5, 5, 5, 5));
+
+		//Performance heading
+		Text performanceHeading = new Text("Performance");
+		performanceHeading.setFont(Font.font("Helvetica", FontWeight.NORMAL, 20));
+		gridpane.add(performanceHeading, 0, 7);
+		GridPane.setColumnSpan(performanceHeading, 2);
+		GridPane.setMargin(performanceHeading, new Insets(15, 5, 5, 5));
+
+		//Molecule record cache look-ahead
+		Label lookAheadLabel = new Label("Records to cache ahead");
+		gridpane.add(lookAheadLabel, 0, 8);
+		GridPane.setMargin(lookAheadLabel, new Insets(5, 5, 5, 5));
+
+		cacheLookAheadSpinner = new Spinner<Integer>(0, 100, prefService.getInt(
+			SettingsTab.class, "recordCacheLookAhead", 10));
+		gridpane.add(cacheLookAheadSpinner, 1, 8);
+		cacheLookAheadSpinner.valueProperty().addListener((t, o, n) -> {
+			prefService.remove(SettingsTab.class, "recordCacheLookAhead");
+			prefService.put(SettingsTab.class, "recordCacheLookAhead", n);
+		});
+		GridPane.setMargin(cacheLookAheadSpinner, new Insets(5, 5, 5, 5));
+
+		//Molecule record cache look-behind
+		Label lookBehindLabel = new Label("Records to cache behind");
+		gridpane.add(lookBehindLabel, 0, 9);
+		GridPane.setMargin(lookBehindLabel, new Insets(5, 5, 5, 5));
+
+		cacheLookBehindSpinner = new Spinner<Integer>(0, 100, prefService.getInt(
+			SettingsTab.class, "recordCacheLookBehind", 3));
+		gridpane.add(cacheLookBehindSpinner, 1, 9);
+		cacheLookBehindSpinner.valueProperty().addListener((t, o, n) -> {
+			prefService.remove(SettingsTab.class, "recordCacheLookBehind");
+			prefService.put(SettingsTab.class, "recordCacheLookBehind", n);
+		});
+		GridPane.setMargin(cacheLookBehindSpinner, new Insets(5, 5, 5, 5));
 
 		rootPane.getChildren().add(gridpane);
 		VBox.setMargin(gridpane, new Insets(15, 15, 15, 15));
@@ -324,6 +363,14 @@ public class SettingsTab extends AbstractMoleculeArchiveTab implements
 
 	public ObservableList<HotKeyEntry> getHotKeyList() {
 		return hotKeyRowList;
+	}
+
+	public Spinner<Integer> getCacheLookAheadSpinner() {
+		return cacheLookAheadSpinner;
+	}
+
+	public Spinner<Integer> getCacheLookBehindSpinner() {
+		return cacheLookBehindSpinner;
 	}
 
 	@Override


### PR DESCRIPTION
Virtual archives re-parse a molecule from disk on every archive.get(), so browsing records was bottlenecked on synchronous file I/O even after gating saves on the dirty flag. MoleculeRecordCache retains loaded records around the current selection, prefetches a window ahead/behind on a single background thread, and saves dirty records asynchronously so the FX thread never blocks on virtual store I/O.

Preserves the one invariant the GUI depends on: the cache always returns the same retained instance for a UID while anything might still reference it (tag hotkeys, notes editor, parameters table, region/position handlers all mutate the molecule in place), never evicts the selected or an unsaved record, and never replaces an already-cached instance with a fresh parse.

Bypassed entirely for in-memory archives, where archive.get/put are already O(1) and already retain a single instance per UID.

- MoleculeRecordCache: get/saveAsync/updateWindow/invalidate(All)/ flushAndWait/shutdown, single daemon I/O thread shared by prefetch and save so writes and reads for the same UID stay ordered.
- AbstractMoleculesTab: wires the cache into the selection listener, lock/unlock events (flush before lock, invalidate after unlock so bulk operations aren't masked by stale retained instances), and the REFRESH_MOLECULE_EVENT handler (invalidate before re-get).
- shutdown() flushes before stopping the executor, which as a side effect now also persists an in-progress edit on the displayed record if the archive window is closed without an explicit save.
- SettingsTab: "Records to cache ahead/behind" spinners (default 10/3), wired to update the live cache immediately via the new MoleculesTab.setCacheLookAhead/Behind methods.