### PR TITLE
Guard markdown preview WebView against zero-height render crash

### DIFF
--- a/src/main/java/de/mpg/biochem/mars/fx/webview/WebViewPreview.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/webview/WebViewPreview.java
@@ -112,6 +112,16 @@ class WebViewPreview implements MarkdownPreviewPane.Preview {
 		webView = new WebView();
 		webView.setFocusTraversable(false);
 
+		// Guard against being laid out at zero height (e.g. before a parent Tab/
+		// SplitPane/VBox has resolved real space): Prism rejects a 0-height render
+		// target with a RuntimeException from ES2RTTexture.create, which crashes the
+		// whole window's render pass, not just this node. A 1px floor keeps the
+		// texture request valid, and hiding the node while its height is still 0
+		// keeps it out of the render pass entirely until real space is allocated.
+		webView.setMinHeight(1);
+		webView.setMinWidth(1);
+		webView.visibleProperty().bind(webView.heightProperty().greaterThan(0));
+
 		// disable WebView default drag and drop handler to allow dropping markdown
 		// files
 		webView.setOnDragEntered(null);


### PR DESCRIPTION
WebView does not protect itself against being laid out at 0 height (e.g. while a parent SplitPane divider is dragged closed, before a TabPane tab has resolved its size, or while a VBox sibling with vgrow ALWAYS hasn't settled). Prism's ES2RTTexture.create rejects a 0-height render target with a RuntimeException on the render thread, which takes down rendering for the whole window, not just the WebView.

WebViewPreview is the single point where the markdown Notes preview WebView is created, shared by MoleculeGeneralTabController, MetadataGeneralTabController, and DatasetExplorerWindow (which has both a SplitPane and JFXTabPanes around its notes section) — so fixing it here covers all call sites. Floor min size at 1px and hide the node while its height is still 0 so it's skipped by the render pass entirely until real space is allocated.