### PR TITLE
Confirm before closing a MoleculeArchive window with unsaved changes

### DIFF
--- a/src/main/java/de/mpg/biochem/mars/fx/bdv/MarsBdvFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/bdv/MarsBdvFrame.java
@@ -485,6 +485,17 @@ public class MarsBdvFrame<T extends NumericType<T> & NativeType<T>> extends
 
 		initBrightness(0.001, 0.999, bdv.getViewerPanel().state(), bdv
 			.getConverterSetups());
+
+		// Track live contrast/color changes made by the user in the viewer so
+		// they count as unsaved changes even before the settings are captured
+		// at serialize-time (see saveSourceDisplaySettings/toJSON).
+		for (SourceAndConverter<?> sourceAndConverter : bdv.getViewerPanel().state()
+			.getSources())
+		{
+			ConverterSetup setup = bdv.getConverterSetups().getConverterSetup(
+				sourceAndConverter);
+			if (setup != null) setup.setupChangeListeners().add(s -> markModified());
+		}
 	}
 
 	private void syncSourceLoaderState(MarsBdvSource marsSource,

--- a/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboard.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboard.java
@@ -50,6 +50,7 @@ import org.scijava.object.ObjectService;
 import org.scijava.plugin.Parameter;
 
 import de.mpg.biochem.mars.fx.dialogs.RoverConfirmationDialog;
+import de.mpg.biochem.mars.fx.event.DashboardChangedEvent;
 import de.mpg.biochem.mars.fx.util.Action;
 import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.util.MarsJFXMasonryPane;
@@ -125,6 +126,7 @@ public abstract class AbstractDashboard<W extends MarsDashboardWidget> extends
 			if (result.get() == ButtonType.OK) {
 				widgets.clear();
 				widgetPane.getChildren().clear();
+				getNode().fireEvent(new DashboardChangedEvent());
 			}
 		});
 
@@ -258,11 +260,13 @@ public abstract class AbstractDashboard<W extends MarsDashboardWidget> extends
 		widgets.add(widget);
 		widgetPane.getChildren().add(widget.getNode());
 		scrollPane.layout();
+		getNode().fireEvent(new DashboardChangedEvent());
 	}
 
 	public void removeWidget(W widget) {
 		widgets.remove(widget);
 		widgetPane.getChildren().remove(widget.getNode());
+		getNode().fireEvent(new DashboardChangedEvent());
 	}
 
 	public ButtonBase createWidgetButton(String widgetName) {

--- a/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboardWidget.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/dashboard/AbstractDashboardWidget.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.scijava.plugin.Parameter;
 
 import de.mpg.biochem.mars.fx.dialogs.RoverConfirmationDialog;
+import de.mpg.biochem.mars.fx.event.DashboardChangedEvent;
 import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.molecule.AbstractJsonConvertibleRecord;
 import javafx.animation.Animation;
@@ -205,9 +206,12 @@ public abstract class AbstractDashboardWidget extends
 	}
 
 	protected void mouseReleased(MouseEvent event) {
+		boolean resized = dragX || dragY;
 		dragX = dragY = false;
 		rootPane.setCursor(Cursor.DEFAULT);
 		tabs.setCursor(Cursor.DEFAULT);
+		if (resized && parent != null) parent.getNode().fireEvent(
+			new DashboardChangedEvent());
 	}
 
 	protected void mouseOver(MouseEvent event) {

--- a/src/main/java/de/mpg/biochem/mars/fx/editor/DocumentEditor.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/editor/DocumentEditor.java
@@ -388,8 +388,6 @@ public class DocumentEditor extends AnchorPane {
 		EmojiSupport.installAutocomplete(markdownEditorPane);
 		markdownPreviewPane = new MarkdownPreviewPane(this);
 
-		// markdownEditorPane.getUndoManager().mark();
-
 		// clear undo history after first load
 		markdownEditorPane.getUndoManager().forgetHistory();
 
@@ -412,10 +410,6 @@ public class DocumentEditor extends AnchorPane {
 		// bind the editor undo manager to the properties
 		UndoManager<?> undoManager = markdownEditorPane.getUndoManager();
 		modified.bind(Bindings.not(undoManager.atMarkedPositionProperty()));
-		modified.addListener((observable, oldValue, isNowModified) -> {
-			if (isNowModified) commentsTab.fireEvent(new DocumentChangedEvent(
-				document));
-		});
 		canUndo.bind(undoManager.undoAvailableProperty());
 		canRedo.bind(undoManager.redoAvailableProperty());
 
@@ -435,6 +429,17 @@ public class DocumentEditor extends AnchorPane {
 		markdownPreviewPane.editorSelectionProperty().set(new IndexRange(-1, -1));
 
 		markdownEditorPane.setMarkdown(document.getContent());
+
+		// Mark this freshly loaded state as the baseline - without this,
+		// loading the initial content moves the undo manager away from its
+		// default marked position, making "modified" spuriously true before
+		// any real edit. Attach the dirty-tracking listener only after the
+		// baseline is established so it doesn't observe that transient.
+		undoManager.mark();
+		modified.addListener((observable, oldValue, isNowModified) -> {
+			if (isNowModified) commentsTab.fireEvent(new DocumentChangedEvent(
+				document));
+		});
 	}
 
 	private boolean updateEditAndPreviewPending;

--- a/src/main/java/de/mpg/biochem/mars/fx/editor/DocumentEditor.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/editor/DocumentEditor.java
@@ -67,6 +67,7 @@ import org.scijava.Context;
 import org.scijava.plugin.Parameter;
 
 import de.mpg.biochem.mars.fx.dialogs.RoverConfirmationDialog;
+import de.mpg.biochem.mars.fx.event.DocumentChangedEvent;
 import de.mpg.biochem.mars.fx.event.RunMoleculeArchiveTaskEvent;
 import de.mpg.biochem.mars.fx.molecule.CommentsTab;
 import de.mpg.biochem.mars.fx.options.MarkdownExtensions;
@@ -159,6 +160,7 @@ public class DocumentEditor extends AnchorPane {
 					document.setName(newName);
 					archive.properties().putDocument(document);
 					label.setText(newName);
+					commentsTab.fireEvent(new DocumentChangedEvent(document));
 				}
 				tab.setGraphic(label);
 			});
@@ -175,6 +177,7 @@ public class DocumentEditor extends AnchorPane {
 						document.setName(newName);
 						archive.properties().putDocument(document);
 						label.setText(newName);
+						commentsTab.fireEvent(new DocumentChangedEvent(document));
 					}
 					tab.setGraphic(label);
 				}
@@ -201,6 +204,7 @@ public class DocumentEditor extends AnchorPane {
 		else {
 			this.document = new MarsDocument(name, "");
 			archive.properties().putDocument(document);
+			commentsTab.fireEvent(new DocumentChangedEvent(document));
 		}
 
 		// avoid that this is GCed
@@ -245,6 +249,7 @@ public class DocumentEditor extends AnchorPane {
 
 	public void close() {
 		archive.properties().removeDocument(document.getName());
+		commentsTab.fireEvent(new DocumentChangedEvent(document));
 	}
 
 	public Context getContext() {
@@ -407,6 +412,10 @@ public class DocumentEditor extends AnchorPane {
 		// bind the editor undo manager to the properties
 		UndoManager<?> undoManager = markdownEditorPane.getUndoManager();
 		modified.bind(Bindings.not(undoManager.atMarkedPositionProperty()));
+		modified.addListener((observable, oldValue, isNowModified) -> {
+			if (isNowModified) commentsTab.fireEvent(new DocumentChangedEvent(
+				document));
+		});
 		canUndo.bind(undoManager.undoAvailableProperty());
 		canRedo.bind(undoManager.redoAvailableProperty());
 

--- a/src/main/java/de/mpg/biochem/mars/fx/event/DashboardChangedEvent.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/event/DashboardChangedEvent.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,50 +27,22 @@
  * #L%
  */
 
-package de.mpg.biochem.mars.fx.dialogs;
+package de.mpg.biochem.mars.fx.event;
 
-import javafx.scene.control.Alert;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.stage.Modality;
-import javafx.stage.Window;
+import javafx.event.Event;
+import javafx.event.EventType;
 
-/**
- * Rover confirmation dialog.
- *
- * @author Karl Duderstadt
- */
-public class RoverConfirmationDialog extends Alert {
+public class DashboardChangedEvent extends Event {
 
-	public RoverConfirmationDialog(Window owner, String message) {
-		super(AlertType.CONFIRMATION);
-		initModality(Modality.WINDOW_MODAL);
-		initOwner(owner);
-		Image image1 = new Image("de/mpg/biochem/mars/fx/images/RoverSmile.png");
-		ImageView imageView = new ImageView(image1);
-		imageView.setFitWidth(80);
-		imageView.setFitHeight(80);
-		setGraphic(imageView);
-		setHeaderText(null);
-		setContentText(message);
-	}
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
 
-	public RoverConfirmationDialog(Window owner, String message,
-		String confirmationName, String cancelName)
-	{
-		this(owner, message);
-		((Button) getDialogPane().lookupButton(ButtonType.OK)).setText(
-			confirmationName);
-		((Button) getDialogPane().lookupButton(ButtonType.CANCEL)).setText(
-			cancelName);
-	}
+	public static final EventType<DashboardChangedEvent> DASHBOARD_CHANGED = new EventType<>(
+		ANY, "DASHBOARD_CHANGED");
 
-	public RoverConfirmationDialog(Window owner, String message,
-		ButtonType... buttonTypes)
-	{
-		this(owner, message);
-		getDialogPane().getButtonTypes().setAll(buttonTypes);
+	public DashboardChangedEvent() {
+		super(DASHBOARD_CHANGED);
 	}
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/event/DocumentChangedEvent.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/event/DocumentChangedEvent.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,50 +27,30 @@
  * #L%
  */
 
-package de.mpg.biochem.mars.fx.dialogs;
+package de.mpg.biochem.mars.fx.event;
 
-import javafx.scene.control.Alert;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.stage.Modality;
-import javafx.stage.Window;
+import de.mpg.biochem.mars.util.MarsDocument;
+import javafx.event.Event;
+import javafx.event.EventType;
 
-/**
- * Rover confirmation dialog.
- *
- * @author Karl Duderstadt
- */
-public class RoverConfirmationDialog extends Alert {
+public class DocumentChangedEvent extends Event {
 
-	public RoverConfirmationDialog(Window owner, String message) {
-		super(AlertType.CONFIRMATION);
-		initModality(Modality.WINDOW_MODAL);
-		initOwner(owner);
-		Image image1 = new Image("de/mpg/biochem/mars/fx/images/RoverSmile.png");
-		ImageView imageView = new ImageView(image1);
-		imageView.setFitWidth(80);
-		imageView.setFitHeight(80);
-		setGraphic(imageView);
-		setHeaderText(null);
-		setContentText(message);
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public static final EventType<DocumentChangedEvent> DOCUMENT_CHANGED = new EventType<>(
+		ANY, "DOCUMENT_CHANGED");
+
+	private final MarsDocument document;
+
+	public DocumentChangedEvent(MarsDocument document) {
+		super(DOCUMENT_CHANGED);
+		this.document = document;
 	}
 
-	public RoverConfirmationDialog(Window owner, String message,
-		String confirmationName, String cancelName)
-	{
-		this(owner, message);
-		((Button) getDialogPane().lookupButton(ButtonType.OK)).setText(
-			confirmationName);
-		((Button) getDialogPane().lookupButton(ButtonType.CANCEL)).setText(
-			cancelName);
-	}
-
-	public RoverConfirmationDialog(Window owner, String message,
-		ButtonType... buttonTypes)
-	{
-		this(owner, message);
-		getDialogPane().getButtonTypes().setAll(buttonTypes);
+	public MarsDocument getDocument() {
+		return document;
 	}
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/event/MetadataParametersChangedEvent.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/event/MetadataParametersChangedEvent.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,50 +27,32 @@
  * #L%
  */
 
-package de.mpg.biochem.mars.fx.dialogs;
+package de.mpg.biochem.mars.fx.event;
 
-import javafx.scene.control.Alert;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.stage.Modality;
-import javafx.stage.Window;
+import de.mpg.biochem.mars.metadata.MarsMetadata;
+import javafx.event.EventType;
 
-/**
- * Rover confirmation dialog.
- *
- * @author Karl Duderstadt
- */
-public class RoverConfirmationDialog extends Alert {
+public class MetadataParametersChangedEvent extends MetadataEvent {
 
-	public RoverConfirmationDialog(Window owner, String message) {
-		super(AlertType.CONFIRMATION);
-		initModality(Modality.WINDOW_MODAL);
-		initOwner(owner);
-		Image image1 = new Image("de/mpg/biochem/mars/fx/images/RoverSmile.png");
-		ImageView imageView = new ImageView(image1);
-		imageView.setFitWidth(80);
-		imageView.setFitHeight(80);
-		setGraphic(imageView);
-		setHeaderText(null);
-		setContentText(message);
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public static final EventType<MetadataEvent> PARAMETERS_CHANGED = new EventType<>(
+		METADATA_EVENT, "PARAMETERS_CHANGED");
+
+	private final MarsMetadata marsImageMetadata;
+
+	public MetadataParametersChangedEvent(MarsMetadata marsImageMetadata) {
+		super(PARAMETERS_CHANGED);
+		this.marsImageMetadata = marsImageMetadata;
 	}
 
-	public RoverConfirmationDialog(Window owner, String message,
-		String confirmationName, String cancelName)
-	{
-		this(owner, message);
-		((Button) getDialogPane().lookupButton(ButtonType.OK)).setText(
-			confirmationName);
-		((Button) getDialogPane().lookupButton(ButtonType.CANCEL)).setText(
-			cancelName);
+	public MarsMetadata getImageMetadata() {
+		return this.marsImageMetadata;
 	}
 
-	public RoverConfirmationDialog(Window owner, String message,
-		ButtonType... buttonTypes)
-	{
-		this(owner, message);
-		getDialogPane().getButtonTypes().setAll(buttonTypes);
-	}
+	@Override
+	public void invokeHandler(MetadataEventHandler handler) {}
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/event/MoleculeParametersChangedEvent.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/event/MoleculeParametersChangedEvent.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,50 +27,32 @@
  * #L%
  */
 
-package de.mpg.biochem.mars.fx.dialogs;
+package de.mpg.biochem.mars.fx.event;
 
-import javafx.scene.control.Alert;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.stage.Modality;
-import javafx.stage.Window;
+import de.mpg.biochem.mars.molecule.Molecule;
+import javafx.event.EventType;
 
-/**
- * Rover confirmation dialog.
- *
- * @author Karl Duderstadt
- */
-public class RoverConfirmationDialog extends Alert {
+public class MoleculeParametersChangedEvent extends MoleculeEvent {
 
-	public RoverConfirmationDialog(Window owner, String message) {
-		super(AlertType.CONFIRMATION);
-		initModality(Modality.WINDOW_MODAL);
-		initOwner(owner);
-		Image image1 = new Image("de/mpg/biochem/mars/fx/images/RoverSmile.png");
-		ImageView imageView = new ImageView(image1);
-		imageView.setFitWidth(80);
-		imageView.setFitHeight(80);
-		setGraphic(imageView);
-		setHeaderText(null);
-		setContentText(message);
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public static final EventType<MoleculeEvent> PARAMETERS_CHANGED = new EventType<>(
+		MOLECULE_EVENT, "PARAMETERS_CHANGED");
+
+	private final Molecule molecule;
+
+	public MoleculeParametersChangedEvent(Molecule molecule) {
+		super(PARAMETERS_CHANGED);
+		this.molecule = molecule;
 	}
 
-	public RoverConfirmationDialog(Window owner, String message,
-		String confirmationName, String cancelName)
-	{
-		this(owner, message);
-		((Button) getDialogPane().lookupButton(ButtonType.OK)).setText(
-			confirmationName);
-		((Button) getDialogPane().lookupButton(ButtonType.CANCEL)).setText(
-			cancelName);
+	public Molecule getMolecule() {
+		return molecule;
 	}
 
-	public RoverConfirmationDialog(Window owner, String message,
-		ButtonType... buttonTypes)
-	{
-		this(owner, message);
-		getDialogPane().getButtonTypes().setAll(buttonTypes);
-	}
+	@Override
+	public void invokeHandler(MoleculeEventHandler handler) {}
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -1480,11 +1480,6 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 	}
 
 	public void close() {
-		// stage.close() below re-triggers stage.setOnHidden, which calls close()
-		// again - guard so that re-entrant call is a no-op instead of hitting a
-		// null archive.
-		if (archive == null) return;
-
 		if (moleculeArchiveService.contains(archive.getName()))
 			moleculeArchiveService.removeArchive(archive);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -270,10 +270,9 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 					confirmAndClose(() -> {
 						// Let stage.close() -> setOnHidden -> close() (above) be
 						// the single call path that performs the real teardown,
-						// on the Swing EDT. Calling close() directly here as well
-						// caused it to run twice, concurrently, from two threads.
-						ijStage.cleanup();
+						// on the Swing EDT.
 						stage.close();
+						//ijStage.cleanup();
 					});
 				});
 			}
@@ -1462,7 +1461,14 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 
 		dialog.showAndWait().ifPresent(result -> {
 			if (result == SAVE_BUTTON_TYPE) saveThenRun(onProceed);
-			else if (result == DISCARD_BUTTON_TYPE) onProceed.run();
+			else if (result == DISCARD_BUTTON_TYPE) {
+				// Defer to a fresh pulse: onProceed (ijStage.cleanup(), an AWT
+				// Frame teardown) must not run nested inside this callback,
+				// which is still logically inside showAndWait()'s own event
+				// loop until this handler returns - doing AWT Frame
+				// dispose()/setVisible() there deadlocks against Swing's EDT.
+				Platform.runLater(onProceed);
+			}
 			// CANCEL_BUTTON_TYPE, or dialog dismissed -> leave the window open
 		});
 	}

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -268,11 +268,10 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 					// the platform's default close behavior.
 					event.consume();
 					confirmAndClose(() -> {
-						// Let stage.close() -> setOnHidden -> close() (above) be
-						// the single call path that performs the real teardown,
-						// on the Swing EDT.
-						stage.close();
-						//ijStage.cleanup();
+						SwingUtilities.invokeLater(() -> {
+							ijStage.cleanup();
+							Platform.runLater(() -> stage.close());
+						});
 					});
 				});
 			}
@@ -534,8 +533,10 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		// null, null, e -> importRoverSettings());
 		Action fileCloseAction = new Action("Close", null, null,
 			e -> confirmAndClose(() -> {
-				ijStage.cleanup();
-				stage.close();
+				SwingUtilities.invokeLater(() -> {
+					ijStage.cleanup();
+					Platform.runLater(() -> stage.close());
+				});
 			}));
 
 		fileMenu = ActionUtils.createMenu("File", fileSaveAction,
@@ -1462,12 +1463,7 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		dialog.showAndWait().ifPresent(result -> {
 			if (result == SAVE_BUTTON_TYPE) saveThenRun(onProceed);
 			else if (result == DISCARD_BUTTON_TYPE) {
-				// Defer to a fresh pulse: onProceed (ijStage.cleanup(), an AWT
-				// Frame teardown) must not run nested inside this callback,
-				// which is still logically inside showAndWait()'s own event
-				// loop until this handler returns - doing AWT Frame
-				// dispose()/setVisible() there deadlocks against Swing's EDT.
-				Platform.runLater(onProceed);
+				onProceed.run();
 			}
 			// CANCEL_BUTTON_TYPE, or dialog dismissed -> leave the window open
 		});

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -1485,15 +1485,6 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		// null archive.
 		if (archive == null) return;
 
-		// WindowManager.removeWindow(...) and MarsBdvFrame's JFrame.dispose()
-		// below are AWT/Swing calls and must run on the EDT, not the JavaFX
-		// Application Thread - redispatch if called from confirmAndClose(),
-		// which runs directly on the FX thread.
-		if (!SwingUtilities.isEventDispatchThread()) {
-			SwingUtilities.invokeLater(this::close);
-			return;
-		}
-
 		if (moleculeArchiveService.contains(archive.getName()))
 			moleculeArchiveService.removeArchive(archive);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -1485,6 +1485,15 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		// null archive.
 		if (archive == null) return;
 
+		// WindowManager.removeWindow(...) and MarsBdvFrame's JFrame.dispose()
+		// below are AWT/Swing calls and must run on the EDT, not the JavaFX
+		// Application Thread - redispatch if called from confirmAndClose(),
+		// which runs directly on the FX thread.
+		if (!SwingUtilities.isEventDispatchThread()) {
+			SwingUtilities.invokeLater(this::close);
+			return;
+		}
+
 		if (moleculeArchiveService.contains(archive.getName()))
 			moleculeArchiveService.removeArchive(archive);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -263,14 +263,18 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 				buildScene();
 
 				stage.setOnCloseRequest(event -> {
+					// Always consume: whether the window actually closes is
+					// decided below, based on the confirmation outcome, not by
+					// the platform's default close behavior.
 					event.consume();
-					// Defer to the next pulse: showAndWait()'s nested event loop,
-					// if started directly inside this WINDOW_CLOSE_REQUEST callback,
-					// can deadlock in this embedded (JFXPanel-hosted) toolkit setup.
-					Platform.runLater(() -> confirmAndClose(() -> {
+					confirmAndClose(() -> {
+						// Let stage.close() -> setOnHidden -> close() (above) be
+						// the single call path that performs the real teardown,
+						// on the Swing EDT. Calling close() directly here as well
+						// caused it to run twice, concurrently, from two threads.
 						ijStage.cleanup();
-						close();
-					}));
+						stage.close();
+					});
 				});
 			}
 		});
@@ -532,7 +536,7 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		Action fileCloseAction = new Action("Close", null, null,
 			e -> confirmAndClose(() -> {
 				ijStage.cleanup();
-				close();
+				stage.close();
 			}));
 
 		fileMenu = ActionUtils.createMenu("File", fileSaveAction,

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -76,7 +76,10 @@ import bdv.util.BdvHandle;
 import de.mpg.biochem.mars.fx.bdv.MarsBdvFrame;
 import de.mpg.biochem.mars.fx.bdv.ViewerTransformSyncStarter;
 import de.mpg.biochem.mars.fx.bdv.ViewerTransformSyncStopper;
+import de.mpg.biochem.mars.fx.event.DashboardChangedEvent;
+import de.mpg.biochem.mars.fx.event.DocumentChangedEvent;
 import de.mpg.biochem.mars.fx.event.InitializeMoleculeArchiveEvent;
+import de.mpg.biochem.mars.fx.event.MetadataParametersChangedEvent;
 import de.mpg.biochem.mars.fx.event.MetadataTagsChangedEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveLockEvent;
@@ -84,12 +87,14 @@ import de.mpg.biochem.mars.fx.event.MoleculeArchiveSavedEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveSavingEvent;
 import de.mpg.biochem.mars.fx.util.ActionUtils;
 import de.mpg.biochem.mars.fx.event.MoleculeArchiveUnlockEvent;
+import de.mpg.biochem.mars.fx.event.MoleculeParametersChangedEvent;
 import de.mpg.biochem.mars.fx.event.MoleculeTagsChangedEvent;
 import de.mpg.biochem.mars.fx.event.RefreshMetadataEvent;
 import de.mpg.biochem.mars.fx.event.RefreshMetadataPropertiesEvent;
 import de.mpg.biochem.mars.fx.event.RefreshMoleculeEvent;
 import de.mpg.biochem.mars.fx.event.RefreshMoleculePropertiesEvent;
 import de.mpg.biochem.mars.fx.event.RunMoleculeArchiveTaskEvent;
+import de.mpg.biochem.mars.fx.plot.event.PlotEvent;
 import de.mpg.biochem.mars.fx.molecule.metadataTab.MetadataSubPane;
 import de.mpg.biochem.mars.fx.molecule.moleculesTab.MoleculeSubPane;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
@@ -113,6 +118,8 @@ import javafx.geometry.Side;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
@@ -191,6 +198,19 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 
 	protected final AtomicBoolean archiveLocked = new AtomicBoolean(false);
 
+	// Tracks whether the archive has edits that would be lost if the window
+	// were closed without saving. BDV viewer display settings are tracked
+	// separately (MarsBdvFrame.isModified()) since MarsBdvFrame lives outside
+	// the JavaFX scene graph and cannot bubble an event to this flag.
+	protected final BooleanProperty dirty = new SimpleBooleanProperty(false);
+
+	private static final ButtonType SAVE_BUTTON_TYPE = new ButtonType("Save",
+		ButtonBar.ButtonData.YES);
+	private static final ButtonType DISCARD_BUTTON_TYPE = new ButtonType(
+		"Discard", ButtonBar.ButtonData.NO);
+	private static final ButtonType CANCEL_BUTTON_TYPE = new ButtonType("Cancel",
+		ButtonBar.ButtonData.CANCEL_CLOSE);
+
 	public AbstractMoleculeArchiveFxFrame(
 		MoleculeArchive<Molecule, MarsMetadata, MoleculeArchiveProperties<Molecule, MarsMetadata>, MoleculeArchiveIndex<Molecule, MarsMetadata>> archive,
 		final Context context)
@@ -243,7 +263,11 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 				buildScene();
 
 				stage.setOnCloseRequest(event -> {
-					ijStage.cleanup();
+					event.consume();
+					confirmAndClose(() -> {
+						ijStage.cleanup();
+						close();
+					});
 				});
 			}
 		});
@@ -344,6 +368,41 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 					}
 				}
 			});
+
+		// Track edits that should be treated as unsaved changes. Note:
+		// RefreshMoleculeEvent/RefreshMetadataEvent are intentionally excluded -
+		// they fire on plain tab-switch (see buildTabs()) with no actual edit.
+		EventHandler<Event> markDirty = e -> dirty.set(true);
+		getNode().addEventFilter(MoleculeTagsChangedEvent.TAGS_CHANGED, markDirty::handle);
+		getNode().addEventFilter(MetadataTagsChangedEvent.TAGS_CHANGED, markDirty::handle);
+		getNode().addEventFilter(
+			RefreshMoleculePropertiesEvent.REFRESH_MOLECULE_PROPERTIES_EVENT,
+			markDirty::handle);
+		getNode().addEventFilter(
+			RefreshMetadataPropertiesEvent.REFRESH_METADATA_PROPERTIES_EVENT,
+			markDirty::handle);
+		getNode().addEventFilter(MoleculeParametersChangedEvent.PARAMETERS_CHANGED,
+			markDirty::handle);
+		getNode().addEventFilter(MetadataParametersChangedEvent.PARAMETERS_CHANGED,
+			markDirty::handle);
+		getNode().addEventFilter(DocumentChangedEvent.DOCUMENT_CHANGED,
+			markDirty::handle);
+		getNode().addEventFilter(DashboardChangedEvent.DASHBOARD_CHANGED,
+			markDirty::handle);
+
+		// Regions/positions, excluding the view-only UPDATE_PLOT_AREA redraw echo
+		getNode().addEventFilter(PlotEvent.PLOT_EVENT, e -> {
+			if (!"UPDATE_PLOT_AREA".equals(e.getEventType().getName())) dirty.set(
+				true);
+		});
+
+		getNode().addEventFilter(MoleculeArchiveSavedEvent.MOLECULE_ARCHIVE_SAVED,
+			e -> Platform.runLater(() -> dirty.set(false)));
+
+		// Anything fired while building/restoring the scene above should not count
+		// as an unsaved change on a freshly opened archive.
+		dirty.set(false);
+
 		return scene;
 	}
 
@@ -467,7 +526,11 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		// I have to check on BDV...
 		// Action importRoverSettingsAction = new Action("Import Rover Settings...",
 		// null, null, e -> importRoverSettings());
-		Action fileCloseAction = new Action("Close", null, null, e -> close());
+		Action fileCloseAction = new Action("Close", null, null,
+			e -> confirmAndClose(() -> {
+				ijStage.cleanup();
+				close();
+			}));
 
 		fileMenu = ActionUtils.createMenu("File", fileSaveAction,
 			fileSaveCopyAction, fileSaveJsonCopyAction, fileSaveVirtualStoreAction,
@@ -1368,6 +1431,54 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		archiveLocked.set(false);
 	}
 
+	private boolean isArchiveDirty() {
+		if (dirty.get()) return true;
+		if (marsBdvFrames != null) for (MarsBdvFrame bdvFrame : marsBdvFrames)
+			if (bdvFrame != null && bdvFrame.isModified()) return true;
+		return false;
+	}
+
+	// Gates window-close behind a Save/Discard/Cancel confirmation whenever
+	// there are unsaved changes. onProceed performs the actual close/teardown
+	// and is only run if the archive is clean, or the user picks Save (after
+	// the save completes) or Discard.
+	private void confirmAndClose(Runnable onProceed) {
+		if (!isArchiveDirty()) {
+			onProceed.run();
+			return;
+		}
+
+		RoverConfirmationDialog dialog = new RoverConfirmationDialog(getNode()
+			.getScene().getWindow(),
+			"This archive has unsaved changes. Would you like to save before closing?",
+			SAVE_BUTTON_TYPE, DISCARD_BUTTON_TYPE, CANCEL_BUTTON_TYPE);
+
+		dialog.showAndWait().ifPresent(result -> {
+			if (result == SAVE_BUTTON_TYPE) saveThenRun(onProceed);
+			else if (result == DISCARD_BUTTON_TYPE) onProceed.run();
+			// CANCEL_BUTTON_TYPE, or dialog dismissed -> leave the window open
+		});
+	}
+
+	// save() is asynchronous (runs on a background Thread via runTask()), so
+	// closing must wait for MoleculeArchiveSavedEvent before proceeding.
+	private void saveThenRun(Runnable onProceed) {
+		EventHandler<MoleculeArchiveEvent> handler =
+			new EventHandler<MoleculeArchiveEvent>()
+			{
+
+				@Override
+				public void handle(MoleculeArchiveEvent e) {
+					getNode().removeEventHandler(
+						MoleculeArchiveSavedEvent.MOLECULE_ARCHIVE_SAVED, this);
+					Platform.runLater(onProceed);
+				}
+			};
+		getNode().addEventHandler(MoleculeArchiveSavedEvent.MOLECULE_ARCHIVE_SAVED,
+			handler);
+		save();
+	}
+
 	public void close() {
 		if (moleculeArchiveService.contains(archive.getName()))
 			moleculeArchiveService.removeArchive(archive);
@@ -1544,6 +1655,9 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		jGenerator.close();
 		outputStream.flush();
 		outputStream.close();
+
+		if (marsBdvFrames != null) for (MarsBdvFrame bdvFrame : marsBdvFrames)
+			if (bdvFrame != null) bdvFrame.setModified(false);
 	}
 
 	protected void saveState(String path) throws IOException {
@@ -1561,6 +1675,9 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 		jGenerator.close();
 		stream.flush();
 		stream.close();
+
+		if (marsBdvFrames != null) for (MarsBdvFrame bdvFrame : marsBdvFrames)
+			if (bdvFrame != null) bdvFrame.setModified(false);
 	}
 
 	protected void loadState() throws IOException {

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -264,10 +264,13 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 
 				stage.setOnCloseRequest(event -> {
 					event.consume();
-					confirmAndClose(() -> {
+					// Defer to the next pulse: showAndWait()'s nested event loop,
+					// if started directly inside this WINDOW_CLOSE_REQUEST callback,
+					// can deadlock in this embedded (JFXPanel-hosted) toolkit setup.
+					Platform.runLater(() -> confirmAndClose(() -> {
 						ijStage.cleanup();
 						close();
-					});
+					}));
 				});
 			}
 		});
@@ -1480,6 +1483,11 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 	}
 
 	public void close() {
+		// stage.close() below re-triggers stage.setOnHidden, which calls close()
+		// again - guard so that re-entrant call is a no-op instead of hitting a
+		// null archive.
+		if (archive == null) return;
+
 		if (moleculeArchiveService.contains(archive.getName()))
 			moleculeArchiveService.removeArchive(archive);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractMoleculeArchiveFxFrame.java
@@ -1480,6 +1480,11 @@ public abstract class AbstractMoleculeArchiveFxFrame<I extends MarsMetadataTab<?
 	}
 
 	public void close() {
+		// stage.close() below re-triggers stage.setOnHidden, which calls close()
+		// again - guard so that re-entrant call is a no-op instead of hitting a
+		// null archive.
+		if (archive == null) return;
+
 		if (moleculeArchiveService.contains(archive.getName()))
 			moleculeArchiveService.removeArchive(archive);
 

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractParametersTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/AbstractParametersTable.java
@@ -150,6 +150,7 @@ public abstract class AbstractParametersTable {
 					removeButton.setOnAction(e -> {
 						record.removeParameter(pRow.getName());
 						loadData();
+						fireParametersChangedEvent();
 					});
 				}
 			});
@@ -247,6 +248,7 @@ public abstract class AbstractParametersTable {
 						checkbox.setSelected(record.getBooleanParameter(row.getName()));
 						checkbox.setOnAction(e -> {
 							record.setParameter(row.getName(), checkbox.isSelected());
+							fireParametersChangedEvent();
 						});
 						setStyle("-fx-alignment: CENTER-LEFT;");
 						setGraphic(checkbox);
@@ -317,6 +319,7 @@ public abstract class AbstractParametersTable {
 					break;
 			}
 			loadData();
+			fireParametersChangedEvent();
 		});
 
 		addParameterField.textProperty().addListener((observable, oldValue,
@@ -375,6 +378,8 @@ public abstract class AbstractParametersTable {
 		return rootPane;
 	}
 
+	protected abstract void fireParametersChangedEvent();
+
 	public void loadData() {
 		parameterRowList.clear();
 		
@@ -427,6 +432,8 @@ public abstract class AbstractParametersTable {
 					key, (Boolean) allParameters.get(key));
 				else record.setParameter(key, (String) allParameters.get(key));
 			}
+
+			fireParametersChangedEvent();
 		}
 
 		public int getType() {
@@ -464,6 +471,7 @@ public abstract class AbstractParametersTable {
 					record.setParameter(getName(), Boolean.valueOf(value));
 					break;
 			}
+			fireParametersChangedEvent();
 		}
 
 	}

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/MetadataPropertiesTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/metadataTab/MetadataPropertiesTable.java
@@ -30,6 +30,7 @@
 package de.mpg.biochem.mars.fx.molecule.metadataTab;
 
 import de.mpg.biochem.mars.fx.event.MetadataEvent;
+import de.mpg.biochem.mars.fx.event.MetadataParametersChangedEvent;
 import de.mpg.biochem.mars.fx.molecule.AbstractParametersTable;
 import de.mpg.biochem.mars.metadata.MarsMetadata;
 import javafx.event.Event;
@@ -58,5 +59,10 @@ public class MetadataPropertiesTable extends AbstractParametersTable implements
 	public void onMetadataSelectionChangedEvent(MarsMetadata marsImageMetadata) {
 		this.record = marsImageMetadata;
 		loadData();
+	}
+
+	@Override
+	protected void fireParametersChangedEvent() {
+		fireEvent(new MetadataParametersChangedEvent((MarsMetadata) record));
 	}
 }

--- a/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/MoleculePropertiesTable.java
+++ b/src/main/java/de/mpg/biochem/mars/fx/molecule/moleculesTab/MoleculePropertiesTable.java
@@ -30,6 +30,7 @@
 package de.mpg.biochem.mars.fx.molecule.moleculesTab;
 
 import de.mpg.biochem.mars.fx.event.MoleculeEvent;
+import de.mpg.biochem.mars.fx.event.MoleculeParametersChangedEvent;
 import de.mpg.biochem.mars.fx.molecule.AbstractParametersTable;
 import de.mpg.biochem.mars.molecule.Molecule;
 import javafx.event.Event;
@@ -58,5 +59,10 @@ public class MoleculePropertiesTable extends AbstractParametersTable implements
 	public void onMoleculeSelectionChangedEvent(Molecule molecule) {
 		this.record = molecule;
 		loadData();
+	}
+
+	@Override
+	protected void fireParametersChangedEvent() {
+		fireEvent(new MoleculeParametersChangedEvent((Molecule) record));
 	}
 }


### PR DESCRIPTION
Closing an archive window (OS close button or File > Close) previously tore the window down unconditionally, silently discarding any unsaved edits. Both close paths now route through a dirty-state check that covers tag edits, general property edits, region/position edits, parameter edits, document edits, dashboard layout changes, and BDV viewer display settings.

When unsaved changes are found, a Save/Discard/Cancel confirmation (RoverConfirmationDialog, extended with a variable-button-type constructor) is shown before the window closes. BDV/dashboard state continues to be written to the .rover file only as part of an explicit archive save, never automatically on close - the dialog is how the user finds out about it.

New events (MoleculeParametersChangedEvent, MetadataParametersChangedEvent, DocumentChangedEvent, DashboardChangedEvent) plug gaps where parameter, document, and dashboard edits previously fired nothing. BDV display-setting changes are tracked live via a ConverterSetup.SetupChangeListener.